### PR TITLE
Gold labels

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -5,4 +5,5 @@ include_trailing_comma=True
 force_grid_wrap=0
 combine_as_imports=True
 line_length=88
-known_third_party = fonduer,transistor_spaces
+known_first_party = hardware_normalizers,transistor_spaces
+known_third_party = fonduer,normalizers

--- a/opamps/data/dev/dev_gold.csv
+++ b/opamps/data/dev/dev_gold.csv
@@ -1,0 +1,4726 @@
+1637fd,LT1637,part_family,Y
+1637fd,LT1637,typ_gbp,1.1 MHz
+1637fd,LT1637,typ_supply_current,230.0 uA
+1637fd,LT1637,typ_supply_current,190.0 uA
+1637fd,LT1637,min_op_supply_volt,2.7 V
+1637fd,LT1637,min_op_supply_volt,±1.35 V
+1637fd,LT1637,max_op_supply_volt,44 V
+1637fd,LT1637,min_op_temp,-55
+1637fd,LT1637,max_op_temp,125
+1637fd,LT1637C,part_family,Y
+1637fd,LT1637C,typ_gbp,1.1 MHz
+1637fd,LT1637C,typ_supply_current,230.0 uA
+1637fd,LT1637C,typ_supply_current,190.0 uA
+1637fd,LT1637C,min_op_supply_volt,2.7 V
+1637fd,LT1637C,min_op_supply_volt,±1.35 V
+1637fd,LT1637C,max_op_supply_volt,44 V
+1637fd,LT1637C,min_op_temp,-40
+1637fd,LT1637C,max_op_temp,85
+1637fd,LT1637I,part_family,Y
+1637fd,LT1637I,typ_gbp,1.1 MHz
+1637fd,LT1637I,typ_supply_current,230.0 uA
+1637fd,LT1637I,typ_supply_current,190.0 uA
+1637fd,LT1637I,min_op_supply_volt,2.7 V
+1637fd,LT1637I,min_op_supply_volt,±1.35 V
+1637fd,LT1637I,max_op_supply_volt,44 V
+1637fd,LT1637I,min_op_temp,-40
+1637fd,LT1637I,max_op_temp,85
+1637fd,LT1637H,part_family,Y
+1637fd,LT1637H,typ_gbp,1.1 MHz
+1637fd,LT1637H,typ_supply_current,230.0 uA
+1637fd,LT1637H,typ_supply_current,190.0 uA
+1637fd,LT1637H,min_op_supply_volt,2.7 V
+1637fd,LT1637H,min_op_supply_volt,±1.35 V
+1637fd,LT1637H,max_op_supply_volt,44 V
+1637fd,LT1637H,min_op_temp,-40
+1637fd,LT1637H,max_op_temp,125
+1637fd,LT1637MP,part_family,Y
+1637fd,LT1637MP,typ_gbp,1.1 MHz
+1637fd,LT1637MP,typ_supply_current,230.0 uA
+1637fd,LT1637MP,typ_supply_current,190.0 uA
+1637fd,LT1637MP,min_op_supply_volt,2.7 V
+1637fd,LT1637MP,min_op_supply_volt,±1.35 V
+1637fd,LT1637MP,max_op_supply_volt,44 V
+1637fd,LT1637MP,min_op_temp,-55
+1637fd,LT1637MP,max_op_temp,125
+1637fd,LT1637CDD,part_family,N
+1637fd,LT1637CDD,typ_gbp,1.1 MHz
+1637fd,LT1637CDD,typ_supply_current,230.0 uA
+1637fd,LT1637CDD,typ_supply_current,190.0 uA
+1637fd,LT1637CDD,min_op_supply_volt,2.7 V
+1637fd,LT1637CDD,min_op_supply_volt,±1.35 V
+1637fd,LT1637CDD,max_op_supply_volt,44 V
+1637fd,LT1637CDD,min_op_temp,-40
+1637fd,LT1637CDD,max_op_temp,85
+1637fd,LT1637IDD,part_family,N
+1637fd,LT1637IDD,typ_gbp,1.1 MHz
+1637fd,LT1637IDD,typ_supply_current,230.0 uA
+1637fd,LT1637IDD,typ_supply_current,190.0 uA
+1637fd,LT1637IDD,min_op_supply_volt,2.7 V
+1637fd,LT1637IDD,min_op_supply_volt,±1.35 V
+1637fd,LT1637IDD,max_op_supply_volt,44 V
+1637fd,LT1637IDD,min_op_temp,-40
+1637fd,LT1637IDD,max_op_temp,85
+1637fd,LT1637CMS8,part_family,N
+1637fd,LT1637CMS8,typ_gbp,1.1 MHz
+1637fd,LT1637CMS8,typ_supply_current,230.0 uA
+1637fd,LT1637CMS8,typ_supply_current,190.0 uA
+1637fd,LT1637CMS8,min_op_supply_volt,2.7 V
+1637fd,LT1637CMS8,min_op_supply_volt,±1.35 V
+1637fd,LT1637CMS8,max_op_supply_volt,44 V
+1637fd,LT1637CMS8,min_op_temp,-40
+1637fd,LT1637CMS8,max_op_temp,85
+1637fd,LT1637IMS8,part_family,N
+1637fd,LT1637IMS8,typ_gbp,1.1 MHz
+1637fd,LT1637IMS8,typ_supply_current,230.0 uA
+1637fd,LT1637IMS8,typ_supply_current,190.0 uA
+1637fd,LT1637IMS8,min_op_supply_volt,2.7 V
+1637fd,LT1637IMS8,min_op_supply_volt,±1.35 V
+1637fd,LT1637IMS8,max_op_supply_volt,44 V
+1637fd,LT1637IMS8,min_op_temp,-40
+1637fd,LT1637IMS8,max_op_temp,85
+1637fd,LT1637CN8,part_family,N
+1637fd,LT1637CN8,typ_gbp,1.1 MHz
+1637fd,LT1637CN8,typ_supply_current,230.0 uA
+1637fd,LT1637CN8,typ_supply_current,190.0 uA
+1637fd,LT1637CN8,min_op_supply_volt,2.7 V
+1637fd,LT1637CN8,min_op_supply_volt,±1.35 V
+1637fd,LT1637CN8,max_op_supply_volt,44 V
+1637fd,LT1637CN8,min_op_temp,-40
+1637fd,LT1637CN8,max_op_temp,85
+1637fd,LT1637CS8,part_family,N
+1637fd,LT1637CS8,typ_gbp,1.1 MHz
+1637fd,LT1637CS8,typ_supply_current,230.0 uA
+1637fd,LT1637CS8,typ_supply_current,190.0 uA
+1637fd,LT1637CS8,min_op_supply_volt,2.7 V
+1637fd,LT1637CS8,min_op_supply_volt,±1.35 V
+1637fd,LT1637CS8,max_op_supply_volt,44 V
+1637fd,LT1637CS8,min_op_temp,-40
+1637fd,LT1637CS8,max_op_temp,85
+1637fd,LT1637IN8,part_family,N
+1637fd,LT1637IN8,typ_gbp,1.1 MHz
+1637fd,LT1637IN8,typ_supply_current,230.0 uA
+1637fd,LT1637IN8,typ_supply_current,190.0 uA
+1637fd,LT1637IN8,min_op_supply_volt,2.7 V
+1637fd,LT1637IN8,min_op_supply_volt,±1.35 V
+1637fd,LT1637IN8,max_op_supply_volt,44 V
+1637fd,LT1637IN8,min_op_temp,-40
+1637fd,LT1637IN8,max_op_temp,85
+1637fd,LT1637IS8,part_family,N
+1637fd,LT1637IS8,typ_gbp,1.1 MHz
+1637fd,LT1637IS8,typ_supply_current,230.0 uA
+1637fd,LT1637IS8,typ_supply_current,190.0 uA
+1637fd,LT1637IS8,min_op_supply_volt,2.7 V
+1637fd,LT1637IS8,min_op_supply_volt,±1.35 V
+1637fd,LT1637IS8,max_op_supply_volt,44 V
+1637fd,LT1637IS8,min_op_temp,-40
+1637fd,LT1637IS8,max_op_temp,85
+1637fd,LT1637HS8,part_family,N
+1637fd,LT1637HS8,typ_gbp,1.1 MHz
+1637fd,LT1637HS8,typ_supply_current,230.0 uA
+1637fd,LT1637HS8,typ_supply_current,190.0 uA
+1637fd,LT1637HS8,min_op_supply_volt,2.7 V
+1637fd,LT1637HS8,min_op_supply_volt,±1.35 V
+1637fd,LT1637HS8,max_op_supply_volt,44 V
+1637fd,LT1637HS8,min_op_temp,-40
+1637fd,LT1637HS8,max_op_temp,125
+1637fd,LT1637MPS8,part_family,N
+1637fd,LT1637MPS8,typ_gbp,1.1 MHz
+1637fd,LT1637MPS8,typ_supply_current,230.0 uA
+1637fd,LT1637MPS8,typ_supply_current,190.0 uA
+1637fd,LT1637MPS8,min_op_supply_volt,2.7 V
+1637fd,LT1637MPS8,min_op_supply_volt,±1.35 V
+1637fd,LT1637MPS8,max_op_supply_volt,44 V
+1637fd,LT1637MPS8,min_op_temp,-55
+1637fd,LT1637MPS8,max_op_temp,125
+ad585,AD585,part_family,Y
+ad585,AD585,min_op_supply_volt,5 V
+ad585,AD585,max_op_supply_volt,±18 V
+ad585,AD585,min_op_temp,-55
+ad585,AD585,max_op_temp,125
+ad585,AD585JP,part_family,N
+ad585,AD585JP,min_op_supply_volt,5 V
+ad585,AD585JP,max_op_supply_volt,±18 V
+ad585,AD585JP,min_op_temp,0
+ad585,AD585JP,max_op_temp,70
+ad585,AD585AQ,part_family,N
+ad585,AD585AQ,min_op_supply_volt,5 V
+ad585,AD585AQ,max_op_supply_volt,±18 V
+ad585,AD585AQ,min_op_temp,-25
+ad585,AD585AQ,max_op_temp,85
+ad585,AD585SQ,part_family,N
+ad585,AD585SQ,min_op_supply_volt,5 V
+ad585,AD585SQ,max_op_supply_volt,±18 V
+ad585,AD585SQ,min_op_temp,-55
+ad585,AD585SQ,max_op_temp,125
+ad585,AD585SE,part_family,N
+ad585,AD585SE,min_op_supply_volt,5 V
+ad585,AD585SE,max_op_supply_volt,±18 V
+ad585,AD585SE,min_op_temp,-55
+ad585,AD585SE,max_op_temp,125
+ad605,AD605,part_family,Y
+ad605,AD605,typ_supply_current,18.0 mA
+ad605,AD605,min_op_supply_volt,4.5 V
+ad605,AD605,max_op_supply_volt,5.5 V
+ad605,AD605,min_op_temp,-40
+ad605,AD605,max_op_temp,85
+ad605,AD605A,part_family,Y
+ad605,AD605A,typ_supply_current,18.0 mA
+ad605,AD605A,min_op_supply_volt,4.5 V
+ad605,AD605A,max_op_supply_volt,5.5 V
+ad605,AD605A,min_op_temp,-40
+ad605,AD605A,max_op_temp,85
+ad605,AD605B,part_family,Y
+ad605,AD605B,typ_supply_current,18.0 mA
+ad605,AD605B,min_op_supply_volt,4.5 V
+ad605,AD605B,max_op_supply_volt,5.5 V
+ad605,AD605B,min_op_temp,-40
+ad605,AD605B,max_op_temp,85
+ad605,AD605AN,part_family,N
+ad605,AD605AN,typ_supply_current,18.0 mA
+ad605,AD605AN,min_op_supply_volt,4.5 V
+ad605,AD605AN,max_op_supply_volt,5.5 V
+ad605,AD605AN,min_op_temp,-40
+ad605,AD605AN,max_op_temp,85
+ad605,AD605ANZ,part_family,N
+ad605,AD605ANZ,typ_supply_current,18.0 mA
+ad605,AD605ANZ,min_op_supply_volt,4.5 V
+ad605,AD605ANZ,max_op_supply_volt,5.5 V
+ad605,AD605ANZ,min_op_temp,-40
+ad605,AD605ANZ,max_op_temp,85
+ad605,AD605AR,part_family,N
+ad605,AD605AR,typ_supply_current,18.0 mA
+ad605,AD605AR,min_op_supply_volt,4.5 V
+ad605,AD605AR,max_op_supply_volt,5.5 V
+ad605,AD605AR,min_op_temp,-40
+ad605,AD605AR,max_op_temp,85
+ad605,AD605AR-REEL,part_family,N
+ad605,AD605AR-REEL,typ_supply_current,18.0 mA
+ad605,AD605AR-REEL,min_op_supply_volt,4.5 V
+ad605,AD605AR-REEL,max_op_supply_volt,5.5 V
+ad605,AD605AR-REEL,min_op_temp,-40
+ad605,AD605AR-REEL,max_op_temp,85
+ad605,AD605AR-REEL7,part_family,N
+ad605,AD605AR-REEL7,typ_supply_current,18.0 mA
+ad605,AD605AR-REEL7,min_op_supply_volt,4.5 V
+ad605,AD605AR-REEL7,max_op_supply_volt,5.5 V
+ad605,AD605AR-REEL7,min_op_temp,-40
+ad605,AD605AR-REEL7,max_op_temp,85
+ad605,AD605ARZ,part_family,N
+ad605,AD605ARZ,typ_supply_current,18.0 mA
+ad605,AD605ARZ,min_op_supply_volt,4.5 V
+ad605,AD605ARZ,max_op_supply_volt,5.5 V
+ad605,AD605ARZ,min_op_temp,-40
+ad605,AD605ARZ,max_op_temp,85
+ad605,AD605AR-RL,part_family,N
+ad605,AD605AR-RL,typ_supply_current,18.0 mA
+ad605,AD605AR-RL,min_op_supply_volt,4.5 V
+ad605,AD605AR-RL,max_op_supply_volt,5.5 V
+ad605,AD605AR-RL,min_op_temp,-40
+ad605,AD605AR-RL,max_op_temp,85
+ad605,AD605AR-RL7,part_family,N
+ad605,AD605AR-RL7,typ_supply_current,18.0 mA
+ad605,AD605AR-RL7,min_op_supply_volt,4.5 V
+ad605,AD605AR-RL7,max_op_supply_volt,5.5 V
+ad605,AD605AR-RL7,min_op_temp,-40
+ad605,AD605AR-RL7,max_op_temp,85
+ad605,AD605BN,part_family,N
+ad605,AD605BN,typ_supply_current,18.0 mA
+ad605,AD605BN,min_op_supply_volt,4.5 V
+ad605,AD605BN,max_op_supply_volt,5.5 V
+ad605,AD605BN,min_op_temp,-40
+ad605,AD605BN,max_op_temp,85
+ad605,AD605BR,part_family,N
+ad605,AD605BR,typ_supply_current,18.0 mA
+ad605,AD605BR,min_op_supply_volt,4.5 V
+ad605,AD605BR,max_op_supply_volt,5.5 V
+ad605,AD605BR,min_op_temp,-40
+ad605,AD605BR,max_op_temp,85
+ad605,AD605BR-REEL,part_family,N
+ad605,AD605BR-REEL,typ_supply_current,18.0 mA
+ad605,AD605BR-REEL,min_op_supply_volt,4.5 V
+ad605,AD605BR-REEL,max_op_supply_volt,5.5 V
+ad605,AD605BR-REEL,min_op_temp,-40
+ad605,AD605BR-REEL,max_op_temp,85
+ad605,AD605BR-REEL7,part_family,N
+ad605,AD605BR-REEL7,typ_supply_current,18.0 mA
+ad605,AD605BR-REEL7,min_op_supply_volt,4.5 V
+ad605,AD605BR-REEL7,max_op_supply_volt,5.5 V
+ad605,AD605BR-REEL7,min_op_temp,-40
+ad605,AD605BR-REEL7,max_op_temp,85
+ad605,AD605BRZ,part_family,N
+ad605,AD605BRZ,typ_supply_current,18.0 mA
+ad605,AD605BRZ,min_op_supply_volt,4.5 V
+ad605,AD605BRZ,max_op_supply_volt,5.5 V
+ad605,AD605BRZ,min_op_temp,-40
+ad605,AD605BRZ,max_op_temp,85
+ad605,AD605BRZ-RL,part_family,N
+ad605,AD605BRZ-RL,typ_supply_current,18.0 mA
+ad605,AD605BRZ-RL,min_op_supply_volt,4.5 V
+ad605,AD605BRZ-RL,max_op_supply_volt,5.5 V
+ad605,AD605BRZ-RL,min_op_temp,-40
+ad605,AD605BRZ-RL,max_op_temp,85
+ad605,AD605BRZ-RL7,part_family,N
+ad605,AD605BRZ-RL7,typ_supply_current,18.0 mA
+ad605,AD605BRZ-RL7,min_op_supply_volt,4.5 V
+ad605,AD605BRZ-RL7,max_op_supply_volt,5.5 V
+ad605,AD605BRZ-RL7,min_op_temp,-40
+ad605,AD605BRZ-RL7,max_op_temp,85
+ad605,AD605-EVALZ,part_family,N
+ad605,AD605-EVALZ,typ_supply_current,18.0 mA
+ad605,AD605-EVALZ,min_op_supply_volt,4.5 V
+ad605,AD605-EVALZ,max_op_supply_volt,5.5 V
+ad605,AD605-EVALZ,min_op_temp,-40
+ad605,AD605-EVALZ,max_op_temp,85
+ad605,AD605ACHIPS,part_family,N
+ad605,AD605ACHIPS,typ_supply_current,18.0 mA
+ad605,AD605ACHIPS,min_op_supply_volt,4.5 V
+ad605,AD605ACHIPS,max_op_supply_volt,5.5 V
+ad605,AD605ACHIPS,min_op_temp,-40
+ad605,AD605ACHIPS,max_op_temp,85
+ad606,AD606,part_family,Y
+ad606,AD606,typ_supply_current,13.0 mA
+ad606,AD606,min_op_supply_volt,4.5 V
+ad606,AD606,max_op_supply_volt,5.5 V
+ad606,AD606,min_op_temp,0
+ad606,AD606,max_op_temp,70
+ad606,AD606J,part_family,Y
+ad606,AD606J,typ_supply_current,13.0 mA
+ad606,AD606J,min_op_supply_volt,4.5 V
+ad606,AD606J,max_op_supply_volt,5.5 V
+ad606,AD606J,min_op_temp,0
+ad606,AD606J,max_op_temp,70
+ad606,AD606JN,part_family,N
+ad606,AD606JN,typ_supply_current,13.0 mA
+ad606,AD606JN,min_op_supply_volt,4.5 V
+ad606,AD606JN,max_op_supply_volt,5.5 V
+ad606,AD606JN,min_op_temp,0
+ad606,AD606JN,max_op_temp,70
+ad606,AD606JR,part_family,N
+ad606,AD606JR,typ_supply_current,13.0 mA
+ad606,AD606JR,min_op_supply_volt,4.5 V
+ad606,AD606JR,max_op_supply_volt,5.5 V
+ad606,AD606JR,min_op_temp,0
+ad606,AD606JR,max_op_temp,70
+ad606,AD606JR-REEL,part_family,N
+ad606,AD606JR-REEL,typ_supply_current,13.0 mA
+ad606,AD606JR-REEL,min_op_supply_volt,4.5 V
+ad606,AD606JR-REEL,max_op_supply_volt,5.5 V
+ad606,AD606JR-REEL,min_op_temp,0
+ad606,AD606JR-REEL,max_op_temp,70
+ad606,AD606JR-REEL7,part_family,N
+ad606,AD606JR-REEL7,typ_supply_current,13.0 mA
+ad606,AD606JR-REEL7,min_op_supply_volt,4.5 V
+ad606,AD606JR-REEL7,max_op_supply_volt,5.5 V
+ad606,AD606JR-REEL7,min_op_temp,0
+ad606,AD606JR-REEL7,max_op_temp,70
+ad606,AD606-EB,part_family,N
+ad606,AD606-EB,typ_supply_current,13.0 mA
+ad606,AD606-EB,min_op_supply_volt,4.5 V
+ad606,AD606-EB,max_op_supply_volt,5.5 V
+ad606,AD606-EB,min_op_temp,0
+ad606,AD606-EB,max_op_temp,70
+ad606,AD606JCHIPS,part_family,N
+ad606,AD606JCHIPS,typ_supply_current,13.0 mA
+ad606,AD606JCHIPS,min_op_supply_volt,4.5 V
+ad606,AD606JCHIPS,max_op_supply_volt,5.5 V
+ad606,AD606JCHIPS,min_op_temp,0
+ad606,AD606JCHIPS,max_op_temp,70
+ad8209,AD8209,part_family,Y
+ad8209,AD8209,typ_supply_current,1.6 mA
+ad8209,AD8209,min_op_supply_volt,4.5 V
+ad8209,AD8209,max_op_supply_volt,5.5 V
+ad8209,AD8209,min_op_temp,-40
+ad8209,AD8209,max_op_temp,150
+ad8209,AD8209WBRM,part_family,Y
+ad8209,AD8209WBRM,typ_supply_current,1.6 mA
+ad8209,AD8209WBRM,min_op_supply_volt,4.5 V
+ad8209,AD8209WBRM,max_op_supply_volt,5.5 V
+ad8209,AD8209WBRM,min_op_temp,-40
+ad8209,AD8209WBRM,max_op_temp,125
+ad8209,AD8209WHRM,part_family,Y
+ad8209,AD8209WHRM,typ_supply_current,1.6 mA
+ad8209,AD8209WHRM,min_op_supply_volt,4.5 V
+ad8209,AD8209WHRM,max_op_supply_volt,5.5 V
+ad8209,AD8209WHRM,min_op_temp,-40
+ad8209,AD8209WHRM,max_op_temp,150
+ad8209,AD8209WBRMZ,part_family,N
+ad8209,AD8209WBRMZ,typ_supply_current,1.6 mA
+ad8209,AD8209WBRMZ,min_op_supply_volt,4.5 V
+ad8209,AD8209WBRMZ,max_op_supply_volt,5.5 V
+ad8209,AD8209WBRMZ,min_op_temp,-40
+ad8209,AD8209WBRMZ,max_op_temp,125
+ad8209,AD8209WBRMZ-R7,part_family,N
+ad8209,AD8209WBRMZ-R7,typ_supply_current,1.6 mA
+ad8209,AD8209WBRMZ-R7,min_op_supply_volt,4.5 V
+ad8209,AD8209WBRMZ-R7,max_op_supply_volt,5.5 V
+ad8209,AD8209WBRMZ-R7,min_op_temp,-40
+ad8209,AD8209WBRMZ-R7,max_op_temp,125
+ad8209,AD8209WBRMZ-RL,part_family,N
+ad8209,AD8209WBRMZ-RL,typ_supply_current,1.6 mA
+ad8209,AD8209WBRMZ-RL,min_op_supply_volt,4.5 V
+ad8209,AD8209WBRMZ-RL,max_op_supply_volt,5.5 V
+ad8209,AD8209WBRMZ-RL,min_op_temp,-40
+ad8209,AD8209WBRMZ-RL,max_op_temp,125
+ad8209,AD8209WHRMZ,part_family,N
+ad8209,AD8209WHRMZ,typ_supply_current,1.6 mA
+ad8209,AD8209WHRMZ,min_op_supply_volt,4.5 V
+ad8209,AD8209WHRMZ,max_op_supply_volt,5.5 V
+ad8209,AD8209WHRMZ,min_op_temp,-40
+ad8209,AD8209WHRMZ,max_op_temp,150
+ad8209,AD8209WHRMZ-RL,part_family,N
+ad8209,AD8209WHRMZ-RL,typ_supply_current,1.6 mA
+ad8209,AD8209WHRMZ-RL,min_op_supply_volt,4.5 V
+ad8209,AD8209WHRMZ-RL,max_op_supply_volt,5.5 V
+ad8209,AD8209WHRMZ-RL,min_op_temp,-40
+ad8209,AD8209WHRMZ-RL,max_op_temp,150
+ad8338,AD8338,part_family,Y
+ad8338,AD8338,min_op_supply_volt,3.0 V
+ad8338,AD8338,max_op_supply_volt,5.0 V
+ad8338,AD8338,min_op_temp,-40
+ad8338,AD8338,max_op_temp,85
+ad8338,AD8338ACPZ-R7,part_family,N
+ad8338,AD8338ACPZ-R7,min_op_supply_volt,3.0 V
+ad8338,AD8338ACPZ-R7,max_op_supply_volt,5.0 V
+ad8338,AD8338ACPZ-R7,min_op_temp,-40
+ad8338,AD8338ACPZ-R7,max_op_temp,85
+ad8338,AD8338ACPZ-RL,part_family,N
+ad8338,AD8338ACPZ-RL,min_op_supply_volt,3.0 V
+ad8338,AD8338ACPZ-RL,max_op_supply_volt,5.0 V
+ad8338,AD8338ACPZ-RL,min_op_temp,-40
+ad8338,AD8338ACPZ-RL,max_op_temp,85
+ad8338,AD8338-EVALZ,part_family,N
+ad8338,AD8338-EVALZ,min_op_supply_volt,3.0 V
+ad8338,AD8338-EVALZ,max_op_supply_volt,5.0 V
+ad8338,AD8338-EVALZ,min_op_temp,-40
+ad8338,AD8338-EVALZ,max_op_temp,85
+ad8519_8529,AD8519,part_family,Y
+ad8519_8529,AD8519,typ_gbp,8.0 MHz
+ad8519_8529,AD8519,typ_gbp,6.0 MHz
+ad8519_8529,AD8519,typ_supply_current,600.0 uA
+ad8519_8529,AD8519,min_op_supply_volt,2.7 V
+ad8519_8529,AD8519,max_op_supply_volt,12 V
+ad8519_8529,AD8519,max_op_supply_volt,±6 V
+ad8519_8529,AD8519,min_op_temp,-40
+ad8519_8529,AD8519,max_op_temp,125
+ad8519_8529,AD8529,part_family,Y
+ad8519_8529,AD8529,typ_gbp,8.0 MHz
+ad8519_8529,AD8529,typ_gbp,6.0 MHz
+ad8519_8529,AD8529,typ_supply_current,600.0 uA
+ad8519_8529,AD8529,min_op_supply_volt,2.7 V
+ad8519_8529,AD8529,max_op_supply_volt,12 V
+ad8519_8529,AD8529,max_op_supply_volt,±6 V
+ad8519_8529,AD8529,min_op_temp,-40
+ad8519_8529,AD8529,max_op_temp,125
+ad8519_8529,AD8519AKS-REEL7,part_family,N
+ad8519_8529,AD8519AKS-REEL7,typ_gbp,8.0 MHz
+ad8519_8529,AD8519AKS-REEL7,typ_gbp,6.0 MHz
+ad8519_8529,AD8519AKS-REEL7,typ_supply_current,600.0 uA
+ad8519_8529,AD8519AKS-REEL7,min_op_supply_volt,2.7 V
+ad8519_8529,AD8519AKS-REEL7,max_op_supply_volt,12 V
+ad8519_8529,AD8519AKS-REEL7,max_op_supply_volt,±6 V
+ad8519_8529,AD8519AKS-REEL7,min_op_temp,-40
+ad8519_8529,AD8519AKS-REEL7,max_op_temp,125
+ad8519_8529,AD8519AKSZ-REEL7,part_family,N
+ad8519_8529,AD8519AKSZ-REEL7,typ_gbp,8.0 MHz
+ad8519_8529,AD8519AKSZ-REEL7,typ_gbp,6.0 MHz
+ad8519_8529,AD8519AKSZ-REEL7,typ_supply_current,600.0 uA
+ad8519_8529,AD8519AKSZ-REEL7,min_op_supply_volt,2.7 V
+ad8519_8529,AD8519AKSZ-REEL7,max_op_supply_volt,12 V
+ad8519_8529,AD8519AKSZ-REEL7,max_op_supply_volt,±6 V
+ad8519_8529,AD8519AKSZ-REEL7,min_op_temp,-40
+ad8519_8529,AD8519AKSZ-REEL7,max_op_temp,125
+ad8519_8529,AD8519ART-REEL,part_family,N
+ad8519_8529,AD8519ART-REEL,typ_gbp,8.0 MHz
+ad8519_8529,AD8519ART-REEL,typ_gbp,6.0 MHz
+ad8519_8529,AD8519ART-REEL,typ_supply_current,600.0 uA
+ad8519_8529,AD8519ART-REEL,min_op_supply_volt,2.7 V
+ad8519_8529,AD8519ART-REEL,max_op_supply_volt,12 V
+ad8519_8529,AD8519ART-REEL,max_op_supply_volt,±6 V
+ad8519_8529,AD8519ART-REEL,min_op_temp,-40
+ad8519_8529,AD8519ART-REEL,max_op_temp,125
+ad8519_8529,AD8519ART-REEL7,part_family,N
+ad8519_8529,AD8519ART-REEL7,typ_gbp,8.0 MHz
+ad8519_8529,AD8519ART-REEL7,typ_gbp,6.0 MHz
+ad8519_8529,AD8519ART-REEL7,typ_supply_current,600.0 uA
+ad8519_8529,AD8519ART-REEL7,min_op_supply_volt,2.7 V
+ad8519_8529,AD8519ART-REEL7,max_op_supply_volt,12 V
+ad8519_8529,AD8519ART-REEL7,max_op_supply_volt,±6 V
+ad8519_8529,AD8519ART-REEL7,min_op_temp,-40
+ad8519_8529,AD8519ART-REEL7,max_op_temp,125
+ad8519_8529,AD8519ARTZ-REEL,part_family,N
+ad8519_8529,AD8519ARTZ-REEL,typ_gbp,8.0 MHz
+ad8519_8529,AD8519ARTZ-REEL,typ_gbp,6.0 MHz
+ad8519_8529,AD8519ARTZ-REEL,typ_supply_current,600.0 uA
+ad8519_8529,AD8519ARTZ-REEL,min_op_supply_volt,2.7 V
+ad8519_8529,AD8519ARTZ-REEL,max_op_supply_volt,12 V
+ad8519_8529,AD8519ARTZ-REEL,max_op_supply_volt,±6 V
+ad8519_8529,AD8519ARTZ-REEL,min_op_temp,-40
+ad8519_8529,AD8519ARTZ-REEL,max_op_temp,125
+ad8519_8529,AD8519ARTZ-REEL7,part_family,N
+ad8519_8529,AD8519ARTZ-REEL7,typ_gbp,8.0 MHz
+ad8519_8529,AD8519ARTZ-REEL7,typ_gbp,6.0 MHz
+ad8519_8529,AD8519ARTZ-REEL7,typ_supply_current,600.0 uA
+ad8519_8529,AD8519ARTZ-REEL7,min_op_supply_volt,2.7 V
+ad8519_8529,AD8519ARTZ-REEL7,max_op_supply_volt,12 V
+ad8519_8529,AD8519ARTZ-REEL7,max_op_supply_volt,±6 V
+ad8519_8529,AD8519ARTZ-REEL7,min_op_temp,-40
+ad8519_8529,AD8519ARTZ-REEL7,max_op_temp,125
+ad8519_8529,AD8519AR,part_family,N
+ad8519_8529,AD8519AR,typ_gbp,8.0 MHz
+ad8519_8529,AD8519AR,typ_gbp,6.0 MHz
+ad8519_8529,AD8519AR,typ_supply_current,600.0 uA
+ad8519_8529,AD8519AR,min_op_supply_volt,2.7 V
+ad8519_8529,AD8519AR,max_op_supply_volt,12 V
+ad8519_8529,AD8519AR,max_op_supply_volt,±6 V
+ad8519_8529,AD8519AR,min_op_temp,-40
+ad8519_8529,AD8519AR,max_op_temp,125
+ad8519_8529,AD8519AR-REEL,part_family,N
+ad8519_8529,AD8519AR-REEL,typ_gbp,8.0 MHz
+ad8519_8529,AD8519AR-REEL,typ_gbp,6.0 MHz
+ad8519_8529,AD8519AR-REEL,typ_supply_current,600.0 uA
+ad8519_8529,AD8519AR-REEL,min_op_supply_volt,2.7 V
+ad8519_8529,AD8519AR-REEL,max_op_supply_volt,12 V
+ad8519_8529,AD8519AR-REEL,max_op_supply_volt,±6 V
+ad8519_8529,AD8519AR-REEL,min_op_temp,-40
+ad8519_8529,AD8519AR-REEL,max_op_temp,125
+ad8519_8529,AD8519AR-REEL7,part_family,N
+ad8519_8529,AD8519AR-REEL7,typ_gbp,8.0 MHz
+ad8519_8529,AD8519AR-REEL7,typ_gbp,6.0 MHz
+ad8519_8529,AD8519AR-REEL7,typ_supply_current,600.0 uA
+ad8519_8529,AD8519AR-REEL7,min_op_supply_volt,2.7 V
+ad8519_8529,AD8519AR-REEL7,max_op_supply_volt,12 V
+ad8519_8529,AD8519AR-REEL7,max_op_supply_volt,±6 V
+ad8519_8529,AD8519AR-REEL7,min_op_temp,-40
+ad8519_8529,AD8519AR-REEL7,max_op_temp,125
+ad8519_8529,AD8519ARZ,part_family,N
+ad8519_8529,AD8519ARZ,typ_gbp,8.0 MHz
+ad8519_8529,AD8519ARZ,typ_gbp,6.0 MHz
+ad8519_8529,AD8519ARZ,typ_supply_current,600.0 uA
+ad8519_8529,AD8519ARZ,min_op_supply_volt,2.7 V
+ad8519_8529,AD8519ARZ,max_op_supply_volt,12 V
+ad8519_8529,AD8519ARZ,max_op_supply_volt,±6 V
+ad8519_8529,AD8519ARZ,min_op_temp,-40
+ad8519_8529,AD8519ARZ,max_op_temp,125
+ad8519_8529,AD8519ARZ-REEL,part_family,N
+ad8519_8529,AD8519ARZ-REEL,typ_gbp,8.0 MHz
+ad8519_8529,AD8519ARZ-REEL,typ_gbp,6.0 MHz
+ad8519_8529,AD8519ARZ-REEL,typ_supply_current,600.0 uA
+ad8519_8529,AD8519ARZ-REEL,min_op_supply_volt,2.7 V
+ad8519_8529,AD8519ARZ-REEL,max_op_supply_volt,12 V
+ad8519_8529,AD8519ARZ-REEL,max_op_supply_volt,±6 V
+ad8519_8529,AD8519ARZ-REEL,min_op_temp,-40
+ad8519_8529,AD8519ARZ-REEL,max_op_temp,125
+ad8519_8529,AD8519ARZ-REEL7,part_family,N
+ad8519_8529,AD8519ARZ-REEL7,typ_gbp,8.0 MHz
+ad8519_8529,AD8519ARZ-REEL7,typ_gbp,6.0 MHz
+ad8519_8529,AD8519ARZ-REEL7,typ_supply_current,600.0 uA
+ad8519_8529,AD8519ARZ-REEL7,min_op_supply_volt,2.7 V
+ad8519_8529,AD8519ARZ-REEL7,max_op_supply_volt,12 V
+ad8519_8529,AD8519ARZ-REEL7,max_op_supply_volt,±6 V
+ad8519_8529,AD8519ARZ-REEL7,min_op_temp,-40
+ad8519_8529,AD8519ARZ-REEL7,max_op_temp,125
+ad8519_8529,AD8529AR,part_family,N
+ad8519_8529,AD8529AR,typ_gbp,8.0 MHz
+ad8519_8529,AD8529AR,typ_gbp,6.0 MHz
+ad8519_8529,AD8529AR,typ_supply_current,600.0 uA
+ad8519_8529,AD8529AR,min_op_supply_volt,2.7 V
+ad8519_8529,AD8529AR,max_op_supply_volt,12 V
+ad8519_8529,AD8529AR,max_op_supply_volt,±6 V
+ad8519_8529,AD8529AR,min_op_temp,-40
+ad8519_8529,AD8529AR,max_op_temp,125
+ad8519_8529,AD8529AR-REEL,part_family,N
+ad8519_8529,AD8529AR-REEL,typ_gbp,8.0 MHz
+ad8519_8529,AD8529AR-REEL,typ_gbp,6.0 MHz
+ad8519_8529,AD8529AR-REEL,typ_supply_current,600.0 uA
+ad8519_8529,AD8529AR-REEL,min_op_supply_volt,2.7 V
+ad8519_8529,AD8529AR-REEL,max_op_supply_volt,12 V
+ad8519_8529,AD8529AR-REEL,max_op_supply_volt,±6 V
+ad8519_8529,AD8529AR-REEL,min_op_temp,-40
+ad8519_8529,AD8529AR-REEL,max_op_temp,125
+ad8519_8529,AD8529ARZ,part_family,N
+ad8519_8529,AD8529ARZ,typ_gbp,8.0 MHz
+ad8519_8529,AD8529ARZ,typ_gbp,6.0 MHz
+ad8519_8529,AD8529ARZ,typ_supply_current,600.0 uA
+ad8519_8529,AD8529ARZ,min_op_supply_volt,2.7 V
+ad8519_8529,AD8529ARZ,max_op_supply_volt,12 V
+ad8519_8529,AD8529ARZ,max_op_supply_volt,±6 V
+ad8519_8529,AD8529ARZ,min_op_temp,-40
+ad8519_8529,AD8529ARZ,max_op_temp,125
+ad8519_8529,AD8529ARZ-REEL,part_family,N
+ad8519_8529,AD8529ARZ-REEL,typ_gbp,8.0 MHz
+ad8519_8529,AD8529ARZ-REEL,typ_gbp,6.0 MHz
+ad8519_8529,AD8529ARZ-REEL,typ_supply_current,600.0 uA
+ad8519_8529,AD8529ARZ-REEL,min_op_supply_volt,2.7 V
+ad8519_8529,AD8529ARZ-REEL,max_op_supply_volt,12 V
+ad8519_8529,AD8529ARZ-REEL,max_op_supply_volt,±6 V
+ad8519_8529,AD8529ARZ-REEL,min_op_temp,-40
+ad8519_8529,AD8529ARZ-REEL,max_op_temp,125
+ad8519_8529,AD8529ARM-REEL,part_family,N
+ad8519_8529,AD8529ARM-REEL,typ_gbp,8.0 MHz
+ad8519_8529,AD8529ARM-REEL,typ_gbp,6.0 MHz
+ad8519_8529,AD8529ARM-REEL,typ_supply_current,600.0 uA
+ad8519_8529,AD8529ARM-REEL,min_op_supply_volt,2.7 V
+ad8519_8529,AD8529ARM-REEL,max_op_supply_volt,12 V
+ad8519_8529,AD8529ARM-REEL,max_op_supply_volt,±6 V
+ad8519_8529,AD8529ARM-REEL,min_op_temp,-40
+ad8519_8529,AD8529ARM-REEL,max_op_temp,125
+ad8519_8529,AD8529ARMZ-REEL,part_family,N
+ad8519_8529,AD8529ARMZ-REEL,typ_gbp,8.0 MHz
+ad8519_8529,AD8529ARMZ-REEL,typ_gbp,6.0 MHz
+ad8519_8529,AD8529ARMZ-REEL,typ_supply_current,600.0 uA
+ad8519_8529,AD8529ARMZ-REEL,min_op_supply_volt,2.7 V
+ad8519_8529,AD8529ARMZ-REEL,max_op_supply_volt,12 V
+ad8519_8529,AD8529ARMZ-REEL,max_op_supply_volt,±6 V
+ad8519_8529,AD8529ARMZ-REEL,min_op_temp,-40
+ad8519_8529,AD8529ARMZ-REEL,max_op_temp,125
+ad8574-ep,AD8574-EP,part_family,Y
+ad8574-ep,AD8574-EP,typ_gbp,1.0 MHz
+ad8574-ep,AD8574-EP,typ_gbp,1.5 MHz
+ad8574-ep,AD8574-EP,typ_supply_current,750.0 uA
+ad8574-ep,AD8574-EP,typ_supply_current,850.0 uA
+ad8574-ep,AD8574-EP,min_op_supply_volt,2.7 V
+ad8574-ep,AD8574-EP,max_op_supply_volt,6 V
+ad8574-ep,AD8574-EP,max_op_supply_volt,5.5 V
+ad8574-ep,AD8574-EP,min_op_temp,-55
+ad8574-ep,AD8574-EP,max_op_temp,125
+ad8574-ep,AD8574TRU-EP,part_family,N
+ad8574-ep,AD8574TRU-EP,typ_gbp,1.0 MHz
+ad8574-ep,AD8574TRU-EP,typ_gbp,1.5 MHz
+ad8574-ep,AD8574TRU-EP,typ_supply_current,750.0 uA
+ad8574-ep,AD8574TRU-EP,typ_supply_current,850.0 uA
+ad8574-ep,AD8574TRU-EP,min_op_supply_volt,2.7 V
+ad8574-ep,AD8574TRU-EP,max_op_supply_volt,6 V
+ad8574-ep,AD8574TRU-EP,max_op_supply_volt,5.5 V
+ad8574-ep,AD8574TRU-EP,min_op_temp,-55
+ad8574-ep,AD8574TRU-EP,max_op_temp,126
+ad8574-ep,AD8574TRU-EP-RL,part_family,N
+ad8574-ep,AD8574TRU-EP-RL,typ_gbp,1.0 MHz
+ad8574-ep,AD8574TRU-EP-RL,typ_gbp,1.5 MHz
+ad8574-ep,AD8574TRU-EP-RL,typ_supply_current,750.0 uA
+ad8574-ep,AD8574TRU-EP-RL,typ_supply_current,850.0 uA
+ad8574-ep,AD8574TRU-EP-RL,min_op_supply_volt,2.7 V
+ad8574-ep,AD8574TRU-EP-RL,max_op_supply_volt,6 V
+ad8574-ep,AD8574TRU-EP-RL,max_op_supply_volt,5.5 V
+ad8574-ep,AD8574TRU-EP-RL,min_op_temp,-55
+ad8574-ep,AD8574TRU-EP-RL,max_op_temp,127
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2,part_family,Y
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2,typ_gbp,3.6 MHz
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2,typ_supply_current,165.0 uA
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2,typ_supply_current,180.0 uA
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2,min_op_supply_volt,2.7 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2,max_op_supply_volt,6 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2,max_op_supply_volt,5.5 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2,min_op_temp,-40
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2,max_op_temp,125
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2ACBZ-R7,part_family,N
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2ACBZ-R7,typ_gbp,3.6 MHz
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2ACBZ-R7,typ_supply_current,165.0 uA
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2ACBZ-R7,typ_supply_current,180.0 uA
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2ACBZ-R7,min_op_supply_volt,2.7 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2ACBZ-R7,max_op_supply_volt,6 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2ACBZ-R7,max_op_supply_volt,5.5 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2ACBZ-R7,min_op_temp,-40
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2ACBZ-R7,max_op_temp,125
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2ACBZ-RL,part_family,N
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2ACBZ-RL,typ_gbp,3.6 MHz
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2ACBZ-RL,typ_supply_current,165.0 uA
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2ACBZ-RL,typ_supply_current,180.0 uA
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2ACBZ-RL,min_op_supply_volt,2.7 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2ACBZ-RL,max_op_supply_volt,6 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2ACBZ-RL,max_op_supply_volt,5.5 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2ACBZ-RL,min_op_temp,-40
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2ACBZ-RL,max_op_temp,125
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2ACPZ-R7,part_family,N
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2ACPZ-R7,typ_gbp,3.6 MHz
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2ACPZ-R7,typ_supply_current,165.0 uA
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2ACPZ-R7,typ_supply_current,180.0 uA
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2ACPZ-R7,min_op_supply_volt,2.7 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2ACPZ-R7,max_op_supply_volt,6 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2ACPZ-R7,max_op_supply_volt,5.5 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2ACPZ-R7,min_op_temp,-40
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2ACPZ-R7,max_op_temp,125
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2ACPZ-RL,part_family,N
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2ACPZ-RL,typ_gbp,3.6 MHz
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2ACPZ-RL,typ_supply_current,165.0 uA
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2ACPZ-RL,typ_supply_current,180.0 uA
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2ACPZ-RL,min_op_supply_volt,2.7 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2ACPZ-RL,max_op_supply_volt,6 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2ACPZ-RL,max_op_supply_volt,5.5 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2ACPZ-RL,min_op_temp,-40
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-2ACPZ-RL,max_op_temp,125
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-4,part_family,Y
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-4,typ_gbp,3.6 MHz
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-4,typ_supply_current,165.0 uA
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-4,typ_supply_current,180.0 uA
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-4,min_op_supply_volt,2.7 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-4,max_op_supply_volt,6 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-4,max_op_supply_volt,5.5 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-4,min_op_temp,-40
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-4,max_op_temp,125
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-4ACPZ-R2,part_family,N
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-4ACPZ-R2,typ_gbp,3.6 MHz
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-4ACPZ-R2,typ_supply_current,165.0 uA
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-4ACPZ-R2,typ_supply_current,180.0 uA
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-4ACPZ-R2,min_op_supply_volt,2.7 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-4ACPZ-R2,max_op_supply_volt,6 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-4ACPZ-R2,max_op_supply_volt,5.5 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-4ACPZ-R2,min_op_temp,-40
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-4ACPZ-R2,max_op_temp,125
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-4ACPZ-R7,part_family,N
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-4ACPZ-R7,typ_gbp,3.6 MHz
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-4ACPZ-R7,typ_supply_current,165.0 uA
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-4ACPZ-R7,typ_supply_current,180.0 uA
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-4ACPZ-R7,min_op_supply_volt,2.7 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-4ACPZ-R7,max_op_supply_volt,6 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-4ACPZ-R7,max_op_supply_volt,5.5 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-4ACPZ-R7,min_op_temp,-40
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-4ACPZ-R7,max_op_temp,125
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-4ACPZ-RL,part_family,N
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-4ACPZ-RL,typ_gbp,3.6 MHz
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-4ACPZ-RL,typ_supply_current,165.0 uA
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-4ACPZ-RL,typ_supply_current,180.0 uA
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-4ACPZ-RL,min_op_supply_volt,2.7 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-4ACPZ-RL,max_op_supply_volt,6 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-4ACPZ-RL,max_op_supply_volt,5.5 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-4ACPZ-RL,min_op_temp,-40
+ada4691-2_4691-4_4692-2_4692-4,ADA4691-4ACPZ-RL,max_op_temp,125
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2,part_family,Y
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2,typ_gbp,3.6 MHz
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2,typ_supply_current,165.0 uA
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2,typ_supply_current,180.0 uA
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2,min_op_supply_volt,2.7 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2,max_op_supply_volt,6 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2,max_op_supply_volt,5.5 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2,min_op_temp,-40
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2,max_op_temp,125
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ACPZ-R7,part_family,N
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ACPZ-R7,typ_gbp,3.6 MHz
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ACPZ-R7,typ_supply_current,165.0 uA
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ACPZ-R7,typ_supply_current,180.0 uA
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ACPZ-R7,min_op_supply_volt,2.7 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ACPZ-R7,max_op_supply_volt,6 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ACPZ-R7,max_op_supply_volt,5.5 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ACPZ-R7,min_op_temp,-40
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ACPZ-R7,max_op_temp,125
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ACPZ-RL,part_family,N
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ACPZ-RL,typ_gbp,3.6 MHz
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ACPZ-RL,typ_supply_current,165.0 uA
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ACPZ-RL,typ_supply_current,180.0 uA
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ACPZ-RL,min_op_supply_volt,2.7 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ACPZ-RL,max_op_supply_volt,6 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ACPZ-RL,max_op_supply_volt,5.5 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ACPZ-RL,min_op_temp,-40
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ACPZ-RL,max_op_temp,125
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ARZ,part_family,N
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ARZ,typ_gbp,3.6 MHz
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ARZ,typ_supply_current,165.0 uA
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ARZ,typ_supply_current,180.0 uA
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ARZ,min_op_supply_volt,2.7 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ARZ,max_op_supply_volt,6 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ARZ,max_op_supply_volt,5.5 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ARZ,min_op_temp,-40
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ARZ,max_op_temp,125
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ARZ-R7,part_family,N
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ARZ-R7,typ_gbp,3.6 MHz
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ARZ-R7,typ_supply_current,165.0 uA
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ARZ-R7,typ_supply_current,180.0 uA
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ARZ-R7,min_op_supply_volt,2.7 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ARZ-R7,max_op_supply_volt,6 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ARZ-R7,max_op_supply_volt,5.5 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ARZ-R7,min_op_temp,-40
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ARZ-R7,max_op_temp,125
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ARZ-RL,part_family,N
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ARZ-RL,typ_gbp,3.6 MHz
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ARZ-RL,typ_supply_current,165.0 uA
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ARZ-RL,typ_supply_current,180.0 uA
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ARZ-RL,min_op_supply_volt,2.7 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ARZ-RL,max_op_supply_volt,6 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ARZ-RL,max_op_supply_volt,5.5 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ARZ-RL,min_op_temp,-40
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-2ARZ-RL,max_op_temp,125
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-4,part_family,Y
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-4,typ_gbp,3.6 MHz
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-4,typ_supply_current,165.0 uA
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-4,typ_supply_current,180.0 uA
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-4,min_op_supply_volt,2.7 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-4,max_op_supply_volt,6 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-4,max_op_supply_volt,5.5 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-4,min_op_temp,-40
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-4,max_op_temp,125
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-4ARUZ,part_family,N
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-4ARUZ,typ_gbp,3.6 MHz
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-4ARUZ,typ_supply_current,165.0 uA
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-4ARUZ,typ_supply_current,180.0 uA
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-4ARUZ,min_op_supply_volt,2.7 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-4ARUZ,max_op_supply_volt,6 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-4ARUZ,max_op_supply_volt,5.5 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-4ARUZ,min_op_temp,-40
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-4ARUZ,max_op_temp,125
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-4ARUZ-RL,part_family,N
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-4ARUZ-RL,typ_gbp,3.6 MHz
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-4ARUZ-RL,typ_supply_current,165.0 uA
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-4ARUZ-RL,typ_supply_current,180.0 uA
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-4ARUZ-RL,min_op_supply_volt,2.7 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-4ARUZ-RL,max_op_supply_volt,6 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-4ARUZ-RL,max_op_supply_volt,5.5 V
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-4ARUZ-RL,min_op_temp,-40
+ada4691-2_4691-4_4692-2_4692-4,ADA4692-4ARUZ-RL,max_op_temp,125
+ada4855-3,ADA4855-3,part_family,Y
+ada4855-3,ADA4855-3,typ_supply_current,7.8 mA
+ada4855-3,ADA4855-3,typ_supply_current,7.5 mA
+ada4855-3,ADA4855-3,min_op_supply_volt,3 V
+ada4855-3,ADA4855-3,max_op_supply_volt,6 V
+ada4855-3,ADA4855-3,max_op_supply_volt,5.5 V
+ada4855-3,ADA4855-3,min_op_temp,-40
+ada4855-3,ADA4855-3,max_op_temp,105
+ada4855-3,ADA4855-3YCPZ-R2,part_family,N
+ada4855-3,ADA4855-3YCPZ-R2,typ_supply_current,7.8 mA
+ada4855-3,ADA4855-3YCPZ-R2,typ_supply_current,7.5 mA
+ada4855-3,ADA4855-3YCPZ-R2,min_op_supply_volt,3 V
+ada4855-3,ADA4855-3YCPZ-R2,max_op_supply_volt,6 V
+ada4855-3,ADA4855-3YCPZ-R2,max_op_supply_volt,5.5 V
+ada4855-3,ADA4855-3YCPZ-R2,min_op_temp,-40
+ada4855-3,ADA4855-3YCPZ-R2,max_op_temp,105
+ada4855-3,ADA4855-3YCPZ-R7,part_family,N
+ada4855-3,ADA4855-3YCPZ-R7,typ_supply_current,7.8 mA
+ada4855-3,ADA4855-3YCPZ-R7,typ_supply_current,7.5 mA
+ada4855-3,ADA4855-3YCPZ-R7,min_op_supply_volt,3 V
+ada4855-3,ADA4855-3YCPZ-R7,max_op_supply_volt,6 V
+ada4855-3,ADA4855-3YCPZ-R7,max_op_supply_volt,5.5 V
+ada4855-3,ADA4855-3YCPZ-R7,min_op_temp,-40
+ada4855-3,ADA4855-3YCPZ-R7,max_op_temp,105
+ada4855-3,ADA4855-3YCPZ-RL,part_family,N
+ada4855-3,ADA4855-3YCPZ-RL,typ_supply_current,7.8 mA
+ada4855-3,ADA4855-3YCPZ-RL,typ_supply_current,7.5 mA
+ada4855-3,ADA4855-3YCPZ-RL,min_op_supply_volt,3 V
+ada4855-3,ADA4855-3YCPZ-RL,max_op_supply_volt,6 V
+ada4855-3,ADA4855-3YCPZ-RL,max_op_supply_volt,5.5 V
+ada4855-3,ADA4855-3YCPZ-RL,min_op_temp,-40
+ada4855-3,ADA4855-3YCPZ-RL,max_op_temp,105
+ada4855-3,ADA4855-3YCP-EBZ,part_family,N
+ada4855-3,ADA4855-3YCP-EBZ,typ_supply_current,7.8 mA
+ada4855-3,ADA4855-3YCP-EBZ,typ_supply_current,7.5 mA
+ada4855-3,ADA4855-3YCP-EBZ,min_op_supply_volt,3 V
+ada4855-3,ADA4855-3YCP-EBZ,max_op_supply_volt,6 V
+ada4855-3,ADA4855-3YCP-EBZ,max_op_supply_volt,5.5 V
+ada4855-3,ADA4855-3YCP-EBZ,min_op_temp,-40
+ada4855-3,ADA4855-3YCP-EBZ,max_op_temp,105
+amc1100,AMC1100,part_family,Y
+amc1100,AMC1100,typ_supply_current,5.4 mA
+amc1100,AMC1100,typ_supply_current,8.0 mA
+amc1100,AMC1100,min_op_supply_volt,2.7 V
+amc1100,AMC1100,max_op_supply_volt,5.5 V
+amc1100,AMC1100,min_op_temp,-40
+amc1100,AMC1100,max_op_temp,105
+amc1100,AMC1100DUB,part_family,N
+amc1100,AMC1100DUB,typ_supply_current,5.4 mA
+amc1100,AMC1100DUB,typ_supply_current,8.0 mA
+amc1100,AMC1100DUB,min_op_supply_volt,2.7 V
+amc1100,AMC1100DUB,max_op_supply_volt,5.5 V
+amc1100,AMC1100DUB,min_op_temp,-40
+amc1100,AMC1100DUB,max_op_temp,105
+amc1100,AMC1100BWV,part_family,N
+amc1100,AMC1100BWV,typ_supply_current,5.4 mA
+amc1100,AMC1100BWV,typ_supply_current,8.0 mA
+amc1100,AMC1100BWV,min_op_supply_volt,2.7 V
+amc1100,AMC1100BWV,max_op_supply_volt,5.5 V
+amc1100,AMC1100BWV,min_op_temp,-40
+amc1100,AMC1100BWV,max_op_temp,105
+clc1200_ds,CLC1200,part_family,Y
+clc1200_ds,CLC1200,typ_supply_current,1.3 mA
+clc1200_ds,CLC1200,min_op_supply_volt,±2.3 V
+clc1200_ds,CLC1200,max_op_supply_volt,±18 V
+clc1200_ds,CLC1200,min_op_temp,-40
+clc1200_ds,CLC1200,max_op_temp,85
+clc1200_ds,CLC1200ISO8X,part_family,N
+clc1200_ds,CLC1200ISO8X,typ_supply_current,1.3 mA
+clc1200_ds,CLC1200ISO8X,min_op_supply_volt,±2.3 V
+clc1200_ds,CLC1200ISO8X,max_op_supply_volt,±18 V
+clc1200_ds,CLC1200ISO8X,min_op_temp,-40
+clc1200_ds,CLC1200ISO8X,max_op_temp,85
+clc1200_ds,CLC1200ISO8MTR,part_family,N
+clc1200_ds,CLC1200ISO8MTR,typ_supply_current,1.3 mA
+clc1200_ds,CLC1200ISO8MTR,min_op_supply_volt,±2.3 V
+clc1200_ds,CLC1200ISO8MTR,max_op_supply_volt,±18 V
+clc1200_ds,CLC1200ISO8MTR,min_op_temp,-40
+clc1200_ds,CLC1200ISO8MTR,max_op_temp,85
+clc1200_ds,CLC1200ISO8EVB,part_family,N
+clc1200_ds,CLC1200ISO8EVB,typ_supply_current,1.3 mA
+clc1200_ds,CLC1200ISO8EVB,min_op_supply_volt,±2.3 V
+clc1200_ds,CLC1200ISO8EVB,max_op_supply_volt,±18 V
+clc1200_ds,CLC1200ISO8EVB,min_op_temp,-40
+clc1200_ds,CLC1200ISO8EVB,max_op_temp,85
+clc1200_ds,CLC1200IDP8,part_family,N
+clc1200_ds,CLC1200IDP8,typ_supply_current,1.3 mA
+clc1200_ds,CLC1200IDP8,min_op_supply_volt,±2.3 V
+clc1200_ds,CLC1200IDP8,max_op_supply_volt,±18 V
+clc1200_ds,CLC1200IDP8,min_op_temp,-40
+clc1200_ds,CLC1200IDP8,max_op_temp,85
+clc406,CLC406,part_family,Y
+clc406,CLC406,typ_supply_current,5.0 mA
+clc406,CLC406,max_op_supply_volt,±7 V
+clc406,CLC406,min_op_temp,-40
+clc406,CLC406,max_op_temp,85
+clc406,CLC406AJP,part_family,N
+clc406,CLC406AJP,typ_supply_current,5.0 mA
+clc406,CLC406AJP,max_op_supply_volt,±7 V
+clc406,CLC406AJP,min_op_temp,-40
+clc406,CLC406AJP,max_op_temp,85
+clc406,CLC406AJE,part_family,N
+clc406,CLC406AJE,typ_supply_current,5.0 mA
+clc406,CLC406AJE,max_op_supply_volt,±7 V
+clc406,CLC406AJE,min_op_temp,-40
+clc406,CLC406AJE,max_op_temp,85
+clc406,CLC406AJM5,part_family,N
+clc406,CLC406AJM5,typ_supply_current,5.0 mA
+clc406,CLC406AJM5,max_op_supply_volt,±7 V
+clc406,CLC406AJM5,min_op_temp,-40
+clc406,CLC406AJM5,max_op_temp,85
+en.cd00000533,LM2902,part_family,Y
+en.cd00000533,LM2902,typ_gbp,1.3 MHz
+en.cd00000533,LM2902,typ_supply_current,0.8 mA
+en.cd00000533,LM2902,typ_supply_current,0.7 mA
+en.cd00000533,LM2902,typ_supply_current,1.5 mA
+en.cd00000533,LM2902,min_op_supply_volt,3 V
+en.cd00000533,LM2902,max_op_supply_volt,±16 V
+en.cd00000533,LM2902,max_op_supply_volt,32 V
+en.cd00000533,LM2902,max_op_supply_volt,30 V
+en.cd00000533,LM2902,min_op_temp,-40
+en.cd00000533,LM2902,max_op_temp,125
+en.cd00000533,LM2902D,part_family,N
+en.cd00000533,LM2902D,typ_gbp,1.3 MHz
+en.cd00000533,LM2902D,typ_supply_current,0.8 mA
+en.cd00000533,LM2902D,typ_supply_current,0.7 mA
+en.cd00000533,LM2902D,typ_supply_current,1.5 mA
+en.cd00000533,LM2902D,min_op_supply_volt,3 V
+en.cd00000533,LM2902D,max_op_supply_volt,±16 V
+en.cd00000533,LM2902D,max_op_supply_volt,32 V
+en.cd00000533,LM2902D,max_op_supply_volt,30 V
+en.cd00000533,LM2902D,min_op_temp,-40
+en.cd00000533,LM2902D,max_op_temp,125
+en.cd00000533,LM2902DT,part_family,N
+en.cd00000533,LM2902DT,typ_gbp,1.3 MHz
+en.cd00000533,LM2902DT,typ_supply_current,0.8 mA
+en.cd00000533,LM2902DT,typ_supply_current,0.7 mA
+en.cd00000533,LM2902DT,typ_supply_current,1.5 mA
+en.cd00000533,LM2902DT,min_op_supply_volt,3 V
+en.cd00000533,LM2902DT,max_op_supply_volt,±16 V
+en.cd00000533,LM2902DT,max_op_supply_volt,32 V
+en.cd00000533,LM2902DT,max_op_supply_volt,30 V
+en.cd00000533,LM2902DT,min_op_temp,-40
+en.cd00000533,LM2902DT,max_op_temp,125
+en.cd00000533,LM2902PT,part_family,N
+en.cd00000533,LM2902PT,typ_gbp,1.3 MHz
+en.cd00000533,LM2902PT,typ_supply_current,0.8 mA
+en.cd00000533,LM2902PT,typ_supply_current,0.7 mA
+en.cd00000533,LM2902PT,typ_supply_current,1.5 mA
+en.cd00000533,LM2902PT,min_op_supply_volt,3 V
+en.cd00000533,LM2902PT,max_op_supply_volt,±16 V
+en.cd00000533,LM2902PT,max_op_supply_volt,32 V
+en.cd00000533,LM2902PT,max_op_supply_volt,30 V
+en.cd00000533,LM2902PT,min_op_temp,-40
+en.cd00000533,LM2902PT,max_op_temp,125
+en.cd00000533,LM2902Q4T,part_family,N
+en.cd00000533,LM2902Q4T,typ_gbp,1.3 MHz
+en.cd00000533,LM2902Q4T,typ_supply_current,0.8 mA
+en.cd00000533,LM2902Q4T,typ_supply_current,0.7 mA
+en.cd00000533,LM2902Q4T,typ_supply_current,1.5 mA
+en.cd00000533,LM2902Q4T,min_op_supply_volt,3 V
+en.cd00000533,LM2902Q4T,max_op_supply_volt,±16 V
+en.cd00000533,LM2902Q4T,max_op_supply_volt,32 V
+en.cd00000533,LM2902Q4T,max_op_supply_volt,30 V
+en.cd00000533,LM2902Q4T,min_op_temp,-40
+en.cd00000533,LM2902Q4T,max_op_temp,125
+en.cd00000533,LM2902YDT,part_family,N
+en.cd00000533,LM2902YDT,typ_gbp,1.3 MHz
+en.cd00000533,LM2902YDT,typ_supply_current,0.8 mA
+en.cd00000533,LM2902YDT,typ_supply_current,0.7 mA
+en.cd00000533,LM2902YDT,typ_supply_current,1.5 mA
+en.cd00000533,LM2902YDT,min_op_supply_volt,3 V
+en.cd00000533,LM2902YDT,max_op_supply_volt,±16 V
+en.cd00000533,LM2902YDT,max_op_supply_volt,32 V
+en.cd00000533,LM2902YDT,max_op_supply_volt,30 V
+en.cd00000533,LM2902YDT,min_op_temp,-40
+en.cd00000533,LM2902YDT,max_op_temp,125
+en.cd00000533,LM2902YPT,part_family,N
+en.cd00000533,LM2902YPT,typ_gbp,1.3 MHz
+en.cd00000533,LM2902YPT,typ_supply_current,0.8 mA
+en.cd00000533,LM2902YPT,typ_supply_current,0.7 mA
+en.cd00000533,LM2902YPT,typ_supply_current,1.5 mA
+en.cd00000533,LM2902YPT,min_op_supply_volt,3 V
+en.cd00000533,LM2902YPT,max_op_supply_volt,±16 V
+en.cd00000533,LM2902YPT,max_op_supply_volt,32 V
+en.cd00000533,LM2902YPT,max_op_supply_volt,30 V
+en.cd00000533,LM2902YPT,min_op_temp,-40
+en.cd00000533,LM2902YPT,max_op_temp,125
+en.cd00003182,TS616,part_family,Y
+en.cd00003182,TS616,typ_supply_current,13.5 mA
+en.cd00003182,TS616,typ_supply_current,11.5 mA
+en.cd00003182,TS616,min_op_supply_volt,±2.5 V
+en.cd00003182,TS616,max_op_supply_volt,±6 V
+en.cd00003182,TS616,min_op_temp,-40
+en.cd00003182,TS616,max_op_temp,85
+en.cd00003182,TS616IDW,part_family,N
+en.cd00003182,TS616IDW,typ_supply_current,13.5 mA
+en.cd00003182,TS616IDW,typ_supply_current,11.5 mA
+en.cd00003182,TS616IDW,min_op_supply_volt,±2.5 V
+en.cd00003182,TS616IDW,max_op_supply_volt,±6 V
+en.cd00003182,TS616IDW,min_op_temp,-40
+en.cd00003182,TS616IDW,max_op_temp,85
+en.cd00003182,TS616IDWT,part_family,N
+en.cd00003182,TS616IDWT,typ_supply_current,13.5 mA
+en.cd00003182,TS616IDWT,typ_supply_current,11.5 mA
+en.cd00003182,TS616IDWT,min_op_supply_volt,±2.5 V
+en.cd00003182,TS616IDWT,max_op_supply_volt,±6 V
+en.cd00003182,TS616IDWT,min_op_temp,-40
+en.cd00003182,TS616IDWT,max_op_temp,85
+en.cd00003594,LM2904WH,part_family,Y
+en.cd00003594,LM2904WH,typ_gbp,1.1 MHz
+en.cd00003594,LM2904WH,typ_supply_current,0.7 mA
+en.cd00003594,LM2904WH,min_op_supply_volt,3 V
+en.cd00003594,LM2904WH,max_op_supply_volt,30 V
+en.cd00003594,LM2904WH,min_op_temp,-40
+en.cd00003594,LM2904WH,max_op_temp,150
+en.cd00003594,LM2904WH-CD1,part_family,N
+en.cd00003594,LM2904WH-CD1,typ_gbp,1.1 MHz
+en.cd00003594,LM2904WH-CD1,typ_supply_current,0.7 mA
+en.cd00003594,LM2904WH-CD1,min_op_supply_volt,3 V
+en.cd00003594,LM2904WH-CD1,max_op_supply_volt,30 V
+en.cd00003594,LM2904WH-CD1,min_op_temp,-40
+en.cd00003594,LM2904WH-CD1,max_op_temp,150
+en.cd00003594,LM2904WHDT,part_family,N
+en.cd00003594,LM2904WHDT,typ_gbp,1.1 MHz
+en.cd00003594,LM2904WHDT,typ_supply_current,0.7 mA
+en.cd00003594,LM2904WHDT,min_op_supply_volt,3 V
+en.cd00003594,LM2904WHDT,max_op_supply_volt,30 V
+en.cd00003594,LM2904WHDT,min_op_temp,-40
+en.cd00003594,LM2904WHDT,max_op_temp,150
+en.cd00003594,LM2904WHYDT,part_family,N
+en.cd00003594,LM2904WHYDT,typ_gbp,1.1 MHz
+en.cd00003594,LM2904WHYDT,typ_supply_current,0.7 mA
+en.cd00003594,LM2904WHYDT,min_op_supply_volt,3 V
+en.cd00003594,LM2904WHYDT,max_op_supply_volt,30 V
+en.cd00003594,LM2904WHYDT,min_op_temp,-40
+en.cd00003594,LM2904WHYDT,max_op_temp,150
+en.cd00003594,LM2904WHYST,part_family,N
+en.cd00003594,LM2904WHYST,typ_gbp,1.1 MHz
+en.cd00003594,LM2904WHYST,typ_supply_current,0.7 mA
+en.cd00003594,LM2904WHYST,min_op_supply_volt,3 V
+en.cd00003594,LM2904WHYST,max_op_supply_volt,30 V
+en.cd00003594,LM2904WHYST,min_op_temp,-40
+en.cd00003594,LM2904WHYST,max_op_temp,150
+en.cd00003601,LM2904W,part_family,Y
+en.cd00003601,LM2904W,typ_gbp,1.1 MHz
+en.cd00003601,LM2904W,typ_supply_current,0.7 mA
+en.cd00003601,LM2904W,min_op_supply_volt,3 V
+en.cd00003601,LM2904W,max_op_supply_volt,30 V
+en.cd00003601,LM2904W,min_op_temp,-40
+en.cd00003601,LM2904W,max_op_temp,125
+en.cd00003601,LM2904WN,part_family,N
+en.cd00003601,LM2904WN,typ_gbp,1.1 MHz
+en.cd00003601,LM2904WN,typ_supply_current,0.7 mA
+en.cd00003601,LM2904WN,min_op_supply_volt,3 V
+en.cd00003601,LM2904WN,max_op_supply_volt,30 V
+en.cd00003601,LM2904WN,min_op_temp,-40
+en.cd00003601,LM2904WN,max_op_temp,125
+en.cd00003601,LM2904WD,part_family,N
+en.cd00003601,LM2904WD,typ_gbp,1.1 MHz
+en.cd00003601,LM2904WD,typ_supply_current,0.7 mA
+en.cd00003601,LM2904WD,min_op_supply_volt,3 V
+en.cd00003601,LM2904WD,max_op_supply_volt,30 V
+en.cd00003601,LM2904WD,min_op_temp,-40
+en.cd00003601,LM2904WD,max_op_temp,125
+en.cd00003601,LM2904WDT,part_family,N
+en.cd00003601,LM2904WDT,typ_gbp,1.1 MHz
+en.cd00003601,LM2904WDT,typ_supply_current,0.7 mA
+en.cd00003601,LM2904WDT,min_op_supply_volt,3 V
+en.cd00003601,LM2904WDT,max_op_supply_volt,30 V
+en.cd00003601,LM2904WDT,min_op_temp,-40
+en.cd00003601,LM2904WDT,max_op_temp,125
+en.cd00003601,LM2904WPT,part_family,N
+en.cd00003601,LM2904WPT,typ_gbp,1.1 MHz
+en.cd00003601,LM2904WPT,typ_supply_current,0.7 mA
+en.cd00003601,LM2904WPT,min_op_supply_volt,3 V
+en.cd00003601,LM2904WPT,max_op_supply_volt,30 V
+en.cd00003601,LM2904WPT,min_op_temp,-40
+en.cd00003601,LM2904WPT,max_op_temp,125
+en.cd00003601,LM2904WYDT,part_family,N
+en.cd00003601,LM2904WYDT,typ_gbp,1.1 MHz
+en.cd00003601,LM2904WYDT,typ_supply_current,0.7 mA
+en.cd00003601,LM2904WYDT,min_op_supply_volt,3 V
+en.cd00003601,LM2904WYDT,max_op_supply_volt,30 V
+en.cd00003601,LM2904WYDT,min_op_temp,-40
+en.cd00003601,LM2904WYDT,max_op_temp,125
+en.cd00003601,LM2904WYPT,part_family,N
+en.cd00003601,LM2904WYPT,typ_gbp,1.1 MHz
+en.cd00003601,LM2904WYPT,typ_supply_current,0.7 mA
+en.cd00003601,LM2904WYPT,min_op_supply_volt,3 V
+en.cd00003601,LM2904WYPT,max_op_supply_volt,30 V
+en.cd00003601,LM2904WYPT,min_op_temp,-40
+en.cd00003601,LM2904WYPT,max_op_temp,125
+en.cd00003601,LM2904AW,part_family,Y
+en.cd00003601,LM2904AW,typ_gbp,1.1 MHz
+en.cd00003601,LM2904AW,typ_supply_current,0.7 mA
+en.cd00003601,LM2904AW,min_op_supply_volt,3 V
+en.cd00003601,LM2904AW,max_op_supply_volt,30 V
+en.cd00003601,LM2904AW,min_op_temp,-40
+en.cd00003601,LM2904AW,max_op_temp,125
+en.cd00003601,LM2904AWYPT,part_family,N
+en.cd00003601,LM2904AWYPT,typ_gbp,1.1 MHz
+en.cd00003601,LM2904AWYPT,typ_supply_current,0.7 mA
+en.cd00003601,LM2904AWYPT,min_op_supply_volt,3 V
+en.cd00003601,LM2904AWYPT,max_op_supply_volt,30 V
+en.cd00003601,LM2904AWYPT,min_op_temp,-40
+en.cd00003601,LM2904AWYPT,max_op_temp,125
+en.dm00078379,TSX920,part_family,Y
+en.dm00078379,TSX920,typ_gbp,9.0 MHz
+en.dm00078379,TSX920,typ_gbp,10.0 MHz
+en.dm00078379,TSX920,typ_supply_current,2.8 mA
+en.dm00078379,TSX920,typ_supply_current,3.1 mA
+en.dm00078379,TSX920,typ_supply_current,2.9 mA
+en.dm00078379,TSX920,min_op_supply_volt,4 V
+en.dm00078379,TSX920,max_op_supply_volt,16 V
+en.dm00078379,TSX920,min_op_temp,-40
+en.dm00078379,TSX920,max_op_temp,125
+en.dm00078379,TSX920ILT,part_family,N
+en.dm00078379,TSX920ILT,typ_gbp,9.0 MHz
+en.dm00078379,TSX920ILT,typ_gbp,10.0 MHz
+en.dm00078379,TSX920ILT,typ_supply_current,2.8 mA
+en.dm00078379,TSX920ILT,typ_supply_current,3.1 mA
+en.dm00078379,TSX920ILT,typ_supply_current,2.9 mA
+en.dm00078379,TSX920ILT,min_op_supply_volt,4 V
+en.dm00078379,TSX920ILT,max_op_supply_volt,16 V
+en.dm00078379,TSX920ILT,min_op_temp,-40
+en.dm00078379,TSX920ILT,max_op_temp,125
+en.dm00078379,TSX921,part_family,Y
+en.dm00078379,TSX921,typ_gbp,9.0 MHz
+en.dm00078379,TSX921,typ_gbp,10.0 MHz
+en.dm00078379,TSX921,typ_supply_current,2.8 mA
+en.dm00078379,TSX921,typ_supply_current,3.1 mA
+en.dm00078379,TSX921,typ_supply_current,2.9 mA
+en.dm00078379,TSX921,min_op_supply_volt,4 V
+en.dm00078379,TSX921,max_op_supply_volt,16 V
+en.dm00078379,TSX921,min_op_temp,-40
+en.dm00078379,TSX921,max_op_temp,125
+en.dm00078379,TSX921ILT,part_family,N
+en.dm00078379,TSX921ILT,typ_gbp,9.0 MHz
+en.dm00078379,TSX921ILT,typ_gbp,10.0 MHz
+en.dm00078379,TSX921ILT,typ_supply_current,2.8 mA
+en.dm00078379,TSX921ILT,typ_supply_current,3.1 mA
+en.dm00078379,TSX921ILT,typ_supply_current,2.9 mA
+en.dm00078379,TSX921ILT,min_op_supply_volt,4 V
+en.dm00078379,TSX921ILT,max_op_supply_volt,16 V
+en.dm00078379,TSX921ILT,min_op_temp,-40
+en.dm00078379,TSX921ILT,max_op_temp,125
+en.dm00078379,TSX921IYLT,part_family,N
+en.dm00078379,TSX921IYLT,typ_gbp,9.0 MHz
+en.dm00078379,TSX921IYLT,typ_gbp,10.0 MHz
+en.dm00078379,TSX921IYLT,typ_supply_current,2.8 mA
+en.dm00078379,TSX921IYLT,typ_supply_current,3.1 mA
+en.dm00078379,TSX921IYLT,typ_supply_current,2.9 mA
+en.dm00078379,TSX921IYLT,min_op_supply_volt,4 V
+en.dm00078379,TSX921IYLT,max_op_supply_volt,16 V
+en.dm00078379,TSX921IYLT,min_op_temp,-40
+en.dm00078379,TSX921IYLT,max_op_temp,125
+en.dm00078379,TSX922,part_family,Y
+en.dm00078379,TSX922,typ_gbp,9.0 MHz
+en.dm00078379,TSX922,typ_gbp,10.0 MHz
+en.dm00078379,TSX922,typ_supply_current,2.8 mA
+en.dm00078379,TSX922,typ_supply_current,3.1 mA
+en.dm00078379,TSX922,typ_supply_current,2.9 mA
+en.dm00078379,TSX922,min_op_supply_volt,4 V
+en.dm00078379,TSX922,max_op_supply_volt,16 V
+en.dm00078379,TSX922,min_op_temp,-40
+en.dm00078379,TSX922,max_op_temp,125
+en.dm00078379,TSX922IDT,part_family,N
+en.dm00078379,TSX922IDT,typ_gbp,9.0 MHz
+en.dm00078379,TSX922IDT,typ_gbp,10.0 MHz
+en.dm00078379,TSX922IDT,typ_supply_current,2.8 mA
+en.dm00078379,TSX922IDT,typ_supply_current,3.1 mA
+en.dm00078379,TSX922IDT,typ_supply_current,2.9 mA
+en.dm00078379,TSX922IDT,min_op_supply_volt,4 V
+en.dm00078379,TSX922IDT,max_op_supply_volt,16 V
+en.dm00078379,TSX922IDT,min_op_temp,-40
+en.dm00078379,TSX922IDT,max_op_temp,125
+en.dm00078379,TSX922IYDT,part_family,N
+en.dm00078379,TSX922IYDT,typ_gbp,9.0 MHz
+en.dm00078379,TSX922IYDT,typ_gbp,10.0 MHz
+en.dm00078379,TSX922IYDT,typ_supply_current,2.8 mA
+en.dm00078379,TSX922IYDT,typ_supply_current,3.1 mA
+en.dm00078379,TSX922IYDT,typ_supply_current,2.9 mA
+en.dm00078379,TSX922IYDT,min_op_supply_volt,4 V
+en.dm00078379,TSX922IYDT,max_op_supply_volt,16 V
+en.dm00078379,TSX922IYDT,min_op_temp,-40
+en.dm00078379,TSX922IYDT,max_op_temp,125
+en.dm00078379,TSX922IST,part_family,N
+en.dm00078379,TSX922IST,typ_gbp,9.0 MHz
+en.dm00078379,TSX922IST,typ_gbp,10.0 MHz
+en.dm00078379,TSX922IST,typ_supply_current,2.8 mA
+en.dm00078379,TSX922IST,typ_supply_current,3.1 mA
+en.dm00078379,TSX922IST,typ_supply_current,2.9 mA
+en.dm00078379,TSX922IST,min_op_supply_volt,4 V
+en.dm00078379,TSX922IST,max_op_supply_volt,16 V
+en.dm00078379,TSX922IST,min_op_temp,-40
+en.dm00078379,TSX922IST,max_op_temp,125
+en.dm00078379,TSX922IQ2T,part_family,N
+en.dm00078379,TSX922IQ2T,typ_gbp,9.0 MHz
+en.dm00078379,TSX922IQ2T,typ_gbp,10.0 MHz
+en.dm00078379,TSX922IQ2T,typ_supply_current,2.8 mA
+en.dm00078379,TSX922IQ2T,typ_supply_current,3.1 mA
+en.dm00078379,TSX922IQ2T,typ_supply_current,2.9 mA
+en.dm00078379,TSX922IQ2T,min_op_supply_volt,4 V
+en.dm00078379,TSX922IQ2T,max_op_supply_volt,16 V
+en.dm00078379,TSX922IQ2T,min_op_temp,-40
+en.dm00078379,TSX922IQ2T,max_op_temp,125
+en.dm00078379,TSX922IYST,part_family,N
+en.dm00078379,TSX922IYST,typ_gbp,9.0 MHz
+en.dm00078379,TSX922IYST,typ_gbp,10.0 MHz
+en.dm00078379,TSX922IYST,typ_supply_current,2.8 mA
+en.dm00078379,TSX922IYST,typ_supply_current,3.1 mA
+en.dm00078379,TSX922IYST,typ_supply_current,2.9 mA
+en.dm00078379,TSX922IYST,min_op_supply_volt,4 V
+en.dm00078379,TSX922IYST,max_op_supply_volt,16 V
+en.dm00078379,TSX922IYST,min_op_temp,-40
+en.dm00078379,TSX922IYST,max_op_temp,125
+en.dm00078379,TSX923,part_family,Y
+en.dm00078379,TSX923,typ_gbp,9.0 MHz
+en.dm00078379,TSX923,typ_gbp,10.0 MHz
+en.dm00078379,TSX923,typ_supply_current,2.8 mA
+en.dm00078379,TSX923,typ_supply_current,3.1 mA
+en.dm00078379,TSX923,typ_supply_current,2.9 mA
+en.dm00078379,TSX923,min_op_supply_volt,4 V
+en.dm00078379,TSX923,max_op_supply_volt,16 V
+en.dm00078379,TSX923,min_op_temp,-40
+en.dm00078379,TSX923,max_op_temp,125
+en.dm00078379,TSX923IST,part_family,N
+en.dm00078379,TSX923IST,typ_gbp,9.0 MHz
+en.dm00078379,TSX923IST,typ_gbp,10.0 MHz
+en.dm00078379,TSX923IST,typ_supply_current,2.8 mA
+en.dm00078379,TSX923IST,typ_supply_current,3.1 mA
+en.dm00078379,TSX923IST,typ_supply_current,2.9 mA
+en.dm00078379,TSX923IST,min_op_supply_volt,4 V
+en.dm00078379,TSX923IST,max_op_supply_volt,16 V
+en.dm00078379,TSX923IST,min_op_temp,-40
+en.dm00078379,TSX923IST,max_op_temp,125
+en.dm00109906,CS70,part_family,Y
+en.dm00109906,CS70,typ_supply_current,200.0 uA
+en.dm00109906,CS70,typ_supply_current,300.0 uA
+en.dm00109906,CS70,min_op_supply_volt,2.7 V
+en.dm00109906,CS70,max_op_supply_volt,5.5 V
+en.dm00109906,CS70,min_op_temp,-40
+en.dm00109906,CS70,max_op_temp,125
+en.dm00109906,CS70P,part_family,N
+en.dm00109906,CS70P,typ_supply_current,200.0 uA
+en.dm00109906,CS70P,typ_supply_current,300.0 uA
+en.dm00109906,CS70P,min_op_supply_volt,2.7 V
+en.dm00109906,CS70P,max_op_supply_volt,5.5 V
+en.dm00109906,CS70P,min_op_temp,-40
+en.dm00109906,CS70P,max_op_temp,125
+hmc914,HMC914LP4E,part_family,N
+hmc914,HMC914LP4E,typ_supply_current,47.0 mA
+hmc914,HMC914LP4E,min_op_supply_volt,3 V
+hmc914,HMC914LP4E,max_op_supply_volt,3.6 V
+hmc914,HMC914LP4E,min_op_temp,-40
+hmc914,HMC914LP4E,max_op_temp,85
+lf411,LF411,part_family,Y
+lf411,LF411,typ_gbp,3.0 MHz
+lf411,LF411,typ_supply_current,2.0 mA
+lf411,LF411,min_op_supply_volt,±3.5 V
+lf411,LF411,max_op_supply_volt,±18 V
+lf411,LF411CD,part_family,N
+lf411,LF411CD,typ_gbp,3.0 MHz
+lf411,LF411CD,typ_supply_current,2.0 mA
+lf411,LF411CD,min_op_supply_volt,±3.5 V
+lf411,LF411CD,max_op_supply_volt,±18 V
+lf411,LF411CD,min_op_temp,0
+lf411,LF411CD,max_op_temp,70
+lf411,LF411ID,part_family,N
+lf411,LF411ID,typ_gbp,3.0 MHz
+lf411,LF411ID,typ_supply_current,2.0 mA
+lf411,LF411ID,min_op_supply_volt,±3.5 V
+lf411,LF411ID,max_op_supply_volt,±18 V
+lf411,LF411ID,min_op_temp,-40
+lf411,LF411ID,max_op_temp,-85
+lf411,LF411CP,part_family,N
+lf411,LF411CP,typ_gbp,3.0 MHz
+lf411,LF411CP,typ_supply_current,2.0 mA
+lf411,LF411CP,min_op_supply_volt,±3.5 V
+lf411,LF411CP,max_op_supply_volt,±18 V
+lf411,LF411CP,min_op_temp,0
+lf411,LF411CP,max_op_temp,70
+lf411,LF411IP,part_family,N
+lf411,LF411IP,typ_gbp,3.0 MHz
+lf411,LF411IP,typ_supply_current,2.0 mA
+lf411,LF411IP,min_op_supply_volt,±3.5 V
+lf411,LF411IP,max_op_supply_volt,±18 V
+lf411,LF411IP,min_op_temp,-40
+lf411,LF411IP,max_op_temp,-85
+lf411,LF411CDR,part_family,N
+lf411,LF411CDR,typ_gbp,3.0 MHz
+lf411,LF411CDR,typ_supply_current,2.0 mA
+lf411,LF411CDR,min_op_supply_volt,±3.5 V
+lf411,LF411CDR,max_op_supply_volt,±18 V
+lf411,LF411CDR,min_op_temp,0
+lf411,LF411CDR,max_op_temp,70
+lf411,LF411IDR,part_family,N
+lf411,LF411IDR,typ_gbp,3.0 MHz
+lf411,LF411IDR,typ_supply_current,2.0 mA
+lf411,LF411IDR,min_op_supply_volt,±3.5 V
+lf411,LF411IDR,max_op_supply_volt,±18 V
+lf411,LF411IDR,min_op_temp,-40
+lf411,LF411IDR,max_op_temp,-85
+lf411,LF411CPR,part_family,N
+lf411,LF411CPR,typ_gbp,3.0 MHz
+lf411,LF411CPR,typ_supply_current,2.0 mA
+lf411,LF411CPR,min_op_supply_volt,±3.5 V
+lf411,LF411CPR,max_op_supply_volt,±18 V
+lf411,LF411CPR,min_op_temp,0
+lf411,LF411CPR,max_op_temp,70
+lf411,LF411IPR,part_family,N
+lf411,LF411IPR,typ_gbp,3.0 MHz
+lf411,LF411IPR,typ_supply_current,2.0 mA
+lf411,LF411IPR,min_op_supply_volt,±3.5 V
+lf411,LF411IPR,max_op_supply_volt,±18 V
+lf411,LF411IPR,min_op_temp,-40
+lf411,LF411IPR,max_op_temp,-85
+lia100,LIA100,part_family,N
+lia100,LIA100,typ_supply_current,5.0 mA
+lia100,LIA100,min_op_supply_volt,±5 V
+lia100,LIA100,max_op_supply_volt,±18 V
+lia100,LIA100,min_op_temp,-40
+lia100,LIA100,max_op_temp,85
+lia100,LIA100P,part_family,N
+lia100,LIA100P,typ_supply_current,5.0 mA
+lia100,LIA100P,min_op_supply_volt,±5 V
+lia100,LIA100P,max_op_supply_volt,±18 V
+lia100,LIA100P,min_op_temp,-40
+lia100,LIA100P,max_op_temp,85
+lia100,LIA100PTR,part_family,N
+lia100,LIA100PTR,typ_supply_current,5.0 mA
+lia100,LIA100PTR,min_op_supply_volt,±5 V
+lia100,LIA100PTR,max_op_supply_volt,±18 V
+lia100,LIA100PTR,min_op_temp,-40
+lia100,LIA100PTR,max_op_temp,85
+lm2902-q1,LM2902-Q1,part_family,Y
+lm2902-q1,LM2902-Q1,typ_gbp,1.2 MHz
+lm2902-q1,LM2902-Q1,typ_supply_current,0.7 mA
+lm2902-q1,LM2902-Q1,typ_supply_current,1.4 mA
+lm2902-q1,LM2902-Q1,min_op_supply_volt,3 V
+lm2902-q1,LM2902-Q1,max_op_supply_volt,32 V
+lm2902-q1,LM2902-Q1,min_op_temp,-40
+lm2902-q1,LM2902-Q1,max_op_temp,125
+lm2902-q1,LM2902QDRQ1,part_family,N
+lm2902-q1,LM2902QDRQ1,typ_gbp,1.2 MHz
+lm2902-q1,LM2902QDRQ1,typ_supply_current,0.7 mA
+lm2902-q1,LM2902QDRQ1,typ_supply_current,1.4 mA
+lm2902-q1,LM2902QDRQ1,min_op_supply_volt,3 V
+lm2902-q1,LM2902QDRQ1,max_op_supply_volt,26 V
+lm2902-q1,LM2902QDRQ1,min_op_temp,-40
+lm2902-q1,LM2902QDRQ1,max_op_temp,125
+lm2902-q1,LM2902QPWRQ1,part_family,N
+lm2902-q1,LM2902QPWRQ1,typ_gbp,1.2 MHz
+lm2902-q1,LM2902QPWRQ1,typ_supply_current,0.7 mA
+lm2902-q1,LM2902QPWRQ1,typ_supply_current,1.4 mA
+lm2902-q1,LM2902QPWRQ1,min_op_supply_volt,3 V
+lm2902-q1,LM2902QPWRQ1,max_op_supply_volt,26 V
+lm2902-q1,LM2902QPWRQ1,min_op_temp,-40
+lm2902-q1,LM2902QPWRQ1,max_op_temp,125
+lm2902-q1,LM2902KVQDRQ1,part_family,N
+lm2902-q1,LM2902KVQDRQ1,typ_gbp,1.2 MHz
+lm2902-q1,LM2902KVQDRQ1,typ_supply_current,0.7 mA
+lm2902-q1,LM2902KVQDRQ1,typ_supply_current,1.4 mA
+lm2902-q1,LM2902KVQDRQ1,min_op_supply_volt,3 V
+lm2902-q1,LM2902KVQDRQ1,max_op_supply_volt,32 V
+lm2902-q1,LM2902KVQDRQ1,min_op_temp,-40
+lm2902-q1,LM2902KVQDRQ1,max_op_temp,125
+lm2902-q1,LM2902KVQPWRQ1,part_family,N
+lm2902-q1,LM2902KVQPWRQ1,typ_gbp,1.2 MHz
+lm2902-q1,LM2902KVQPWRQ1,typ_supply_current,0.7 mA
+lm2902-q1,LM2902KVQPWRQ1,typ_supply_current,1.4 mA
+lm2902-q1,LM2902KVQPWRQ1,min_op_supply_volt,3 V
+lm2902-q1,LM2902KVQPWRQ1,max_op_supply_volt,32 V
+lm2902-q1,LM2902KVQPWRQ1,min_op_temp,-40
+lm2902-q1,LM2902KVQPWRQ1,max_op_temp,125
+lm2902-q1,LM2902KAVQDRQ1,part_family,N
+lm2902-q1,LM2902KAVQDRQ1,typ_gbp,1.2 MHz
+lm2902-q1,LM2902KAVQDRQ1,typ_supply_current,0.7 mA
+lm2902-q1,LM2902KAVQDRQ1,typ_supply_current,1.4 mA
+lm2902-q1,LM2902KAVQDRQ1,min_op_supply_volt,3 V
+lm2902-q1,LM2902KAVQDRQ1,max_op_supply_volt,32 V
+lm2902-q1,LM2902KAVQDRQ1,min_op_temp,-40
+lm2902-q1,LM2902KAVQDRQ1,max_op_temp,125
+lm2902-q1,LM2902KAVQPWRQ1,part_family,N
+lm2902-q1,LM2902KAVQPWRQ1,typ_gbp,1.2 MHz
+lm2902-q1,LM2902KAVQPWRQ1,typ_supply_current,0.7 mA
+lm2902-q1,LM2902KAVQPWRQ1,typ_supply_current,1.4 mA
+lm2902-q1,LM2902KAVQPWRQ1,min_op_supply_volt,3 V
+lm2902-q1,LM2902KAVQPWRQ1,max_op_supply_volt,32 V
+lm2902-q1,LM2902KAVQPWRQ1,min_op_temp,-40
+lm2902-q1,LM2902KAVQPWRQ1,max_op_temp,125
+lm7372,LM7372,part_family,Y
+lm7372,LM7372,typ_gbp,100.0 MHz
+lm7372,LM7372,typ_gbp,120.0 MHz
+lm7372,LM7372,typ_supply_current,13.0 mA
+lm7372,LM7372,typ_supply_current,12.4 mA
+lm7372,LM7372,min_op_supply_volt,9 V
+lm7372,LM7372,max_op_supply_volt,36 V
+lm7372,LM7372,min_op_temp,-40
+lm7372,LM7372,max_op_temp,85
+lm7372,LM7372IMA,part_family,N
+lm7372,LM7372IMA,typ_gbp,100.0 MHz
+lm7372,LM7372IMA,typ_gbp,120.0 MHz
+lm7372,LM7372IMA,typ_supply_current,13.0 mA
+lm7372,LM7372IMA,typ_supply_current,12.4 mA
+lm7372,LM7372IMA,min_op_supply_volt,9 V
+lm7372,LM7372IMA,max_op_supply_volt,36 V
+lm7372,LM7372IMA,min_op_temp,-40
+lm7372,LM7372IMA,max_op_temp,85
+lm7372,LM7372IMA/NOPB,part_family,N
+lm7372,LM7372IMA/NOPB,typ_gbp,100.0 MHz
+lm7372,LM7372IMA/NOPB,typ_gbp,120.0 MHz
+lm7372,LM7372IMA/NOPB,typ_supply_current,13.0 mA
+lm7372,LM7372IMA/NOPB,typ_supply_current,12.4 mA
+lm7372,LM7372IMA/NOPB,min_op_supply_volt,9 V
+lm7372,LM7372IMA/NOPB,max_op_supply_volt,36 V
+lm7372,LM7372IMA/NOPB,min_op_temp,-40
+lm7372,LM7372IMA/NOPB,max_op_temp,85
+lm7372,LM7372IMAZ/NOPB,part_family,N
+lm7372,LM7372IMAZ/NOPB,typ_gbp,100.0 MHz
+lm7372,LM7372IMAZ/NOPB,typ_gbp,120.0 MHz
+lm7372,LM7372IMAZ/NOPB,typ_supply_current,13.0 mA
+lm7372,LM7372IMAZ/NOPB,typ_supply_current,12.4 mA
+lm7372,LM7372IMAZ/NOPB,min_op_supply_volt,9 V
+lm7372,LM7372IMAZ/NOPB,max_op_supply_volt,36 V
+lm7372,LM7372IMAZ/NOPB,min_op_temp,-40
+lm7372,LM7372IMAZ/NOPB,max_op_temp,85
+lm7372,LM7372MR,part_family,N
+lm7372,LM7372MR,typ_gbp,100.0 MHz
+lm7372,LM7372MR,typ_gbp,120.0 MHz
+lm7372,LM7372MR,typ_supply_current,13.0 mA
+lm7372,LM7372MR,typ_supply_current,12.4 mA
+lm7372,LM7372MR,min_op_supply_volt,9 V
+lm7372,LM7372MR,max_op_supply_volt,36 V
+lm7372,LM7372MR,min_op_temp,-40
+lm7372,LM7372MR,max_op_temp,85
+lm7372,LM7372MR/NOPB,part_family,N
+lm7372,LM7372MR/NOPB,typ_gbp,100.0 MHz
+lm7372,LM7372MR/NOPB,typ_gbp,120.0 MHz
+lm7372,LM7372MR/NOPB,typ_supply_current,13.0 mA
+lm7372,LM7372MR/NOPB,typ_supply_current,12.4 mA
+lm7372,LM7372MR/NOPB,min_op_supply_volt,9 V
+lm7372,LM7372MR/NOPB,max_op_supply_volt,36 V
+lm7372,LM7372MR/NOPB,min_op_temp,-40
+lm7372,LM7372MR/NOPB,max_op_temp,85
+lm7372,LM7372MRX,part_family,N
+lm7372,LM7372MRX,typ_gbp,100.0 MHz
+lm7372,LM7372MRX,typ_gbp,120.0 MHz
+lm7372,LM7372MRX,typ_supply_current,13.0 mA
+lm7372,LM7372MRX,typ_supply_current,12.4 mA
+lm7372,LM7372MRX,min_op_supply_volt,9 V
+lm7372,LM7372MRX,max_op_supply_volt,36 V
+lm7372,LM7372MRX,min_op_temp,-40
+lm7372,LM7372MRX,max_op_temp,85
+lm7372,LM7372MRX/NOPB,part_family,N
+lm7372,LM7372MRX/NOPB,typ_gbp,100.0 MHz
+lm7372,LM7372MRX/NOPB,typ_gbp,120.0 MHz
+lm7372,LM7372MRX/NOPB,typ_supply_current,13.0 mA
+lm7372,LM7372MRX/NOPB,typ_supply_current,12.4 mA
+lm7372,LM7372MRX/NOPB,min_op_supply_volt,9 V
+lm7372,LM7372MRX/NOPB,max_op_supply_volt,36 V
+lm7372,LM7372MRX/NOPB,min_op_temp,-40
+lm7372,LM7372MRX/NOPB,max_op_temp,85
+lmc6442_april162015,LMC6442,part_family,Y
+lmc6442_april162015,LMC6442,typ_gbp,9.5 kHz
+lmc6442_april162015,LMC6442,typ_supply_current,1.9 uA
+lmc6442_april162015,LMC6442,min_op_supply_volt,1.8 V
+lmc6442_april162015,LMC6442,max_op_supply_volt,11 V
+lmc6442_april162015,LMC6442,min_op_temp,-40
+lmc6442_april162015,LMC6442,max_op_temp,85
+lmc6442_april162015,LMC6442AIM,part_family,N
+lmc6442_april162015,LMC6442AIM,typ_gbp,9.5 kHz
+lmc6442_april162015,LMC6442AIM,typ_supply_current,1.9 uA
+lmc6442_april162015,LMC6442AIM,min_op_supply_volt,1.8 V
+lmc6442_april162015,LMC6442AIM,max_op_supply_volt,11 V
+lmc6442_april162015,LMC6442AIM,min_op_temp,-40
+lmc6442_april162015,LMC6442AIM,max_op_temp,85
+lmc6442_april162015,LMC6442IM,part_family,N
+lmc6442_april162015,LMC6442IM,typ_gbp,9.5 kHz
+lmc6442_april162015,LMC6442IM,typ_supply_current,1.9 uA
+lmc6442_april162015,LMC6442IM,min_op_supply_volt,1.8 V
+lmc6442_april162015,LMC6442IM,max_op_supply_volt,11 V
+lmc6442_april162015,LMC6442IM,min_op_temp,-40
+lmc6442_april162015,LMC6442IM,max_op_temp,85
+lmc6442_april162015,LMC6442AIMX,part_family,N
+lmc6442_april162015,LMC6442AIMX,typ_gbp,9.5 kHz
+lmc6442_april162015,LMC6442AIMX,typ_supply_current,1.9 uA
+lmc6442_april162015,LMC6442AIMX,min_op_supply_volt,1.8 V
+lmc6442_april162015,LMC6442AIMX,max_op_supply_volt,11 V
+lmc6442_april162015,LMC6442AIMX,min_op_temp,-40
+lmc6442_april162015,LMC6442AIMX,max_op_temp,85
+lmc6442_april162015,LMC6442IMX,part_family,N
+lmc6442_april162015,LMC6442IMX,typ_gbp,9.5 kHz
+lmc6442_april162015,LMC6442IMX,typ_supply_current,1.9 uA
+lmc6442_april162015,LMC6442IMX,min_op_supply_volt,1.8 V
+lmc6442_april162015,LMC6442IMX,max_op_supply_volt,11 V
+lmc6442_april162015,LMC6442IMX,min_op_temp,-40
+lmc6442_april162015,LMC6442IMX,max_op_temp,85
+lmc6442_april162015,LMC6442AIMM,part_family,N
+lmc6442_april162015,LMC6442AIMM,typ_gbp,9.5 kHz
+lmc6442_april162015,LMC6442AIMM,typ_supply_current,1.9 uA
+lmc6442_april162015,LMC6442AIMM,min_op_supply_volt,1.8 V
+lmc6442_april162015,LMC6442AIMM,max_op_supply_volt,11 V
+lmc6442_april162015,LMC6442AIMM,min_op_temp,-40
+lmc6442_april162015,LMC6442AIMM,max_op_temp,85
+lmc6442_april162015,LMC6442AIMMX,part_family,N
+lmc6442_april162015,LMC6442AIMMX,typ_gbp,9.5 kHz
+lmc6442_april162015,LMC6442AIMMX,typ_supply_current,1.9 uA
+lmc6442_april162015,LMC6442AIMMX,min_op_supply_volt,1.8 V
+lmc6442_april162015,LMC6442AIMMX,max_op_supply_volt,11 V
+lmc6442_april162015,LMC6442AIMMX,min_op_temp,-40
+lmc6442_april162015,LMC6442AIMMX,max_op_temp,85
+lmc6442_april162015,LMC6442IMM,part_family,N
+lmc6442_april162015,LMC6442IMM,typ_gbp,9.5 kHz
+lmc6442_april162015,LMC6442IMM,typ_supply_current,1.9 uA
+lmc6442_april162015,LMC6442IMM,min_op_supply_volt,1.8 V
+lmc6442_april162015,LMC6442IMM,max_op_supply_volt,11 V
+lmc6442_april162015,LMC6442IMM,min_op_temp,-40
+lmc6442_april162015,LMC6442IMM,max_op_temp,85
+lmc6442_april162015,LMC6442IMMX,part_family,N
+lmc6442_april162015,LMC6442IMMX,typ_gbp,9.5 kHz
+lmc6442_april162015,LMC6442IMMX,typ_supply_current,1.9 uA
+lmc6442_april162015,LMC6442IMMX,min_op_supply_volt,1.8 V
+lmc6442_april162015,LMC6442IMMX,max_op_supply_volt,11 V
+lmc6442_april162015,LMC6442IMMX,min_op_temp,-40
+lmc6442_april162015,LMC6442IMMX,max_op_temp,85
+lmc6442_april162015,LMC6442AIN,part_family,N
+lmc6442_april162015,LMC6442AIN,typ_gbp,9.5 kHz
+lmc6442_april162015,LMC6442AIN,typ_supply_current,1.9 uA
+lmc6442_april162015,LMC6442AIN,min_op_supply_volt,1.8 V
+lmc6442_april162015,LMC6442AIN,max_op_supply_volt,11 V
+lmc6442_april162015,LMC6442AIN,min_op_temp,-40
+lmc6442_april162015,LMC6442AIN,max_op_temp,85
+lmc6442_april162015,LMC6442IN,part_family,N
+lmc6442_april162015,LMC6442IN,typ_gbp,9.5 kHz
+lmc6442_april162015,LMC6442IN,typ_supply_current,1.9 uA
+lmc6442_april162015,LMC6442IN,min_op_supply_volt,1.8 V
+lmc6442_april162015,LMC6442IN,max_op_supply_volt,11 V
+lmc6442_april162015,LMC6442IN,min_op_temp,-40
+lmc6442_april162015,LMC6442IN,max_op_temp,85
+lmc6442_april162015,5962-9761301QPA,part_family,N
+lmc6442_april162015,5962-9761301QPA,typ_gbp,9.5 kHz
+lmc6442_april162015,5962-9761301QPA,typ_supply_current,1.9 uA
+lmc6442_april162015,5962-9761301QPA,min_op_supply_volt,1.8 V
+lmc6442_april162015,5962-9761301QPA,max_op_supply_volt,11 V
+lmc6442_april162015,5962-9761301QPA,min_op_temp,-55
+lmc6442_april162015,5962-9761301QPA,max_op_temp,125
+lmc6442_april162015,5962-9761301QXA,part_family,N
+lmc6442_april162015,5962-9761301QXA,typ_gbp,9.5 kHz
+lmc6442_april162015,5962-9761301QXA,typ_supply_current,1.9 uA
+lmc6442_april162015,5962-9761301QXA,min_op_supply_volt,1.8 V
+lmc6442_april162015,5962-9761301QXA,max_op_supply_volt,11 V
+lmc6442_april162015,5962-9761301QXA,min_op_temp,-55
+lmc6442_april162015,5962-9761301QXA,max_op_temp,125
+lmc6462_lmc6464,LMC6462,part_family,Y
+lmc6462_lmc6464,LMC6462,typ_gbp,50.0 kHz
+lmc6462_lmc6464,LMC6462,typ_supply_current,20.0 uA
+lmc6462_lmc6464,LMC6462,typ_supply_current,25.0 uA
+lmc6462_lmc6464,LMC6462,min_op_supply_volt,3.0 V
+lmc6462_lmc6464,LMC6462,max_op_supply_volt,15.5 V
+lmc6462_lmc6464,LMC6462,min_op_temp,-40
+lmc6462_lmc6464,LMC6462,max_op_temp,85
+lmc6462_lmc6464,LMC6462AIM,part_family,N
+lmc6462_lmc6464,LMC6462AIM,typ_gbp,50.0 kHz
+lmc6462_lmc6464,LMC6462AIM,typ_supply_current,20.0 uA
+lmc6462_lmc6464,LMC6462AIM,typ_supply_current,25.0 uA
+lmc6462_lmc6464,LMC6462AIM,min_op_supply_volt,3.0 V
+lmc6462_lmc6464,LMC6462AIM,max_op_supply_volt,15.5 V
+lmc6462_lmc6464,LMC6462AIM,min_op_temp,-40
+lmc6462_lmc6464,LMC6462AIM,max_op_temp,85
+lmc6462_lmc6464,LMC6462AIM/NOPB,part_family,N
+lmc6462_lmc6464,LMC6462AIM/NOPB,typ_gbp,50.0 kHz
+lmc6462_lmc6464,LMC6462AIM/NOPB,typ_supply_current,20.0 uA
+lmc6462_lmc6464,LMC6462AIM/NOPB,typ_supply_current,25.0 uA
+lmc6462_lmc6464,LMC6462AIM/NOPB,min_op_supply_volt,3.0 V
+lmc6462_lmc6464,LMC6462AIM/NOPB,max_op_supply_volt,15.5 V
+lmc6462_lmc6464,LMC6462AIM/NOPB,min_op_temp,-40
+lmc6462_lmc6464,LMC6462AIM/NOPB,max_op_temp,85
+lmc6462_lmc6464,LMC6462AIMX/NOPB,part_family,N
+lmc6462_lmc6464,LMC6462AIMX/NOPB,typ_gbp,50.0 kHz
+lmc6462_lmc6464,LMC6462AIMX/NOPB,typ_supply_current,20.0 uA
+lmc6462_lmc6464,LMC6462AIMX/NOPB,typ_supply_current,25.0 uA
+lmc6462_lmc6464,LMC6462AIMX/NOPB,min_op_supply_volt,3.0 V
+lmc6462_lmc6464,LMC6462AIMX/NOPB,max_op_supply_volt,15.5 V
+lmc6462_lmc6464,LMC6462AIMX/NOPB,min_op_temp,-40
+lmc6462_lmc6464,LMC6462AIMX/NOPB,max_op_temp,85
+lmc6462_lmc6464,LMC6462AIN,part_family,N
+lmc6462_lmc6464,LMC6462AIN,typ_gbp,50.0 kHz
+lmc6462_lmc6464,LMC6462AIN,typ_supply_current,20.0 uA
+lmc6462_lmc6464,LMC6462AIN,typ_supply_current,25.0 uA
+lmc6462_lmc6464,LMC6462AIN,min_op_supply_volt,3.0 V
+lmc6462_lmc6464,LMC6462AIN,max_op_supply_volt,15.5 V
+lmc6462_lmc6464,LMC6462AIN,min_op_temp,-40
+lmc6462_lmc6464,LMC6462AIN,max_op_temp,85
+lmc6462_lmc6464,LMC6462AIN/NOPB,part_family,N
+lmc6462_lmc6464,LMC6462AIN/NOPB,typ_gbp,50.0 kHz
+lmc6462_lmc6464,LMC6462AIN/NOPB,typ_supply_current,20.0 uA
+lmc6462_lmc6464,LMC6462AIN/NOPB,typ_supply_current,25.0 uA
+lmc6462_lmc6464,LMC6462AIN/NOPB,min_op_supply_volt,3.0 V
+lmc6462_lmc6464,LMC6462AIN/NOPB,max_op_supply_volt,15.5 V
+lmc6462_lmc6464,LMC6462AIN/NOPB,min_op_temp,-40
+lmc6462_lmc6464,LMC6462AIN/NOPB,max_op_temp,85
+lmc6462_lmc6464,LMC6462BIM/NOPB,part_family,N
+lmc6462_lmc6464,LMC6462BIM/NOPB,typ_gbp,50.0 kHz
+lmc6462_lmc6464,LMC6462BIM/NOPB,typ_supply_current,20.0 uA
+lmc6462_lmc6464,LMC6462BIM/NOPB,typ_supply_current,25.0 uA
+lmc6462_lmc6464,LMC6462BIM/NOPB,min_op_supply_volt,3.0 V
+lmc6462_lmc6464,LMC6462BIM/NOPB,max_op_supply_volt,15.5 V
+lmc6462_lmc6464,LMC6462BIM/NOPB,min_op_temp,-40
+lmc6462_lmc6464,LMC6462BIM/NOPB,max_op_temp,85
+lmc6462_lmc6464,LMC6462BIMX/NOPB,part_family,N
+lmc6462_lmc6464,LMC6462BIMX/NOPB,typ_gbp,50.0 kHz
+lmc6462_lmc6464,LMC6462BIMX/NOPB,typ_supply_current,20.0 uA
+lmc6462_lmc6464,LMC6462BIMX/NOPB,typ_supply_current,25.0 uA
+lmc6462_lmc6464,LMC6462BIMX/NOPB,min_op_supply_volt,3.0 V
+lmc6462_lmc6464,LMC6462BIMX/NOPB,max_op_supply_volt,15.5 V
+lmc6462_lmc6464,LMC6462BIMX/NOPB,min_op_temp,-40
+lmc6462_lmc6464,LMC6462BIMX/NOPB,max_op_temp,85
+lmc6462_lmc6464,LMC6462BIN,part_family,N
+lmc6462_lmc6464,LMC6462BIN,typ_gbp,50.0 kHz
+lmc6462_lmc6464,LMC6462BIN,typ_supply_current,20.0 uA
+lmc6462_lmc6464,LMC6462BIN,typ_supply_current,25.0 uA
+lmc6462_lmc6464,LMC6462BIN,min_op_supply_volt,3.0 V
+lmc6462_lmc6464,LMC6462BIN,max_op_supply_volt,15.5 V
+lmc6462_lmc6464,LMC6462BIN,min_op_temp,-40
+lmc6462_lmc6464,LMC6462BIN,max_op_temp,85
+lmc6462_lmc6464,LMC6462BIN/NOPB,part_family,N
+lmc6462_lmc6464,LMC6462BIN/NOPB,typ_gbp,50.0 kHz
+lmc6462_lmc6464,LMC6462BIN/NOPB,typ_supply_current,20.0 uA
+lmc6462_lmc6464,LMC6462BIN/NOPB,typ_supply_current,25.0 uA
+lmc6462_lmc6464,LMC6462BIN/NOPB,min_op_supply_volt,3.0 V
+lmc6462_lmc6464,LMC6462BIN/NOPB,max_op_supply_volt,15.5 V
+lmc6462_lmc6464,LMC6462BIN/NOPB,min_op_temp,-40
+lmc6462_lmc6464,LMC6462BIN/NOPB,max_op_temp,85
+lmc6462_lmc6464,LMC6464,part_family,Y
+lmc6462_lmc6464,LMC6464,typ_gbp,50.0 kHz
+lmc6462_lmc6464,LMC6464,typ_supply_current,20.0 uA
+lmc6462_lmc6464,LMC6464,typ_supply_current,22.5 uA
+lmc6462_lmc6464,LMC6464,min_op_supply_volt,3.0 V
+lmc6462_lmc6464,LMC6464,max_op_supply_volt,15.5 V
+lmc6462_lmc6464,LMC6464,min_op_temp,-40
+lmc6462_lmc6464,LMC6464,max_op_temp,85
+lmc6462_lmc6464,LMC6464AIM,part_family,N
+lmc6462_lmc6464,LMC6464AIM,typ_gbp,50.0 kHz
+lmc6462_lmc6464,LMC6464AIM,typ_supply_current,20.0 uA
+lmc6462_lmc6464,LMC6464AIM,typ_supply_current,22.5 uA
+lmc6462_lmc6464,LMC6464AIM,min_op_supply_volt,3.0 V
+lmc6462_lmc6464,LMC6464AIM,max_op_supply_volt,15.5 V
+lmc6462_lmc6464,LMC6464AIM,min_op_temp,-40
+lmc6462_lmc6464,LMC6464AIM,max_op_temp,85
+lmc6462_lmc6464,LMC6464AIM/NOPB,part_family,N
+lmc6462_lmc6464,LMC6464AIM/NOPB,typ_gbp,50.0 kHz
+lmc6462_lmc6464,LMC6464AIM/NOPB,typ_supply_current,20.0 uA
+lmc6462_lmc6464,LMC6464AIM/NOPB,typ_supply_current,22.5 uA
+lmc6462_lmc6464,LMC6464AIM/NOPB,min_op_supply_volt,3.0 V
+lmc6462_lmc6464,LMC6464AIM/NOPB,max_op_supply_volt,15.5 V
+lmc6462_lmc6464,LMC6464AIM/NOPB,min_op_temp,-40
+lmc6462_lmc6464,LMC6464AIM/NOPB,max_op_temp,85
+lmc6462_lmc6464,LMC6464AIMX,part_family,N
+lmc6462_lmc6464,LMC6464AIMX,typ_gbp,50.0 kHz
+lmc6462_lmc6464,LMC6464AIMX,typ_supply_current,20.0 uA
+lmc6462_lmc6464,LMC6464AIMX,typ_supply_current,22.5 uA
+lmc6462_lmc6464,LMC6464AIMX,min_op_supply_volt,3.0 V
+lmc6462_lmc6464,LMC6464AIMX,max_op_supply_volt,15.5 V
+lmc6462_lmc6464,LMC6464AIMX,min_op_temp,-40
+lmc6462_lmc6464,LMC6464AIMX,max_op_temp,85
+lmc6462_lmc6464,LMC6464AIMX/NOPB,part_family,N
+lmc6462_lmc6464,LMC6464AIMX/NOPB,typ_gbp,50.0 kHz
+lmc6462_lmc6464,LMC6464AIMX/NOPB,typ_supply_current,20.0 uA
+lmc6462_lmc6464,LMC6464AIMX/NOPB,typ_supply_current,22.5 uA
+lmc6462_lmc6464,LMC6464AIMX/NOPB,min_op_supply_volt,3.0 V
+lmc6462_lmc6464,LMC6464AIMX/NOPB,max_op_supply_volt,15.5 V
+lmc6462_lmc6464,LMC6464AIMX/NOPB,min_op_temp,-40
+lmc6462_lmc6464,LMC6464AIMX/NOPB,max_op_temp,85
+lmc6462_lmc6464,LMC6464BIM,part_family,N
+lmc6462_lmc6464,LMC6464BIM,typ_gbp,50.0 kHz
+lmc6462_lmc6464,LMC6464BIM,typ_supply_current,20.0 uA
+lmc6462_lmc6464,LMC6464BIM,typ_supply_current,22.5 uA
+lmc6462_lmc6464,LMC6464BIM,min_op_supply_volt,3.0 V
+lmc6462_lmc6464,LMC6464BIM,max_op_supply_volt,15.5 V
+lmc6462_lmc6464,LMC6464BIM,min_op_temp,-40
+lmc6462_lmc6464,LMC6464BIM,max_op_temp,85
+lmc6462_lmc6464,LMC6464BIM/NOPB,part_family,N
+lmc6462_lmc6464,LMC6464BIM/NOPB,typ_gbp,50.0 kHz
+lmc6462_lmc6464,LMC6464BIM/NOPB,typ_supply_current,20.0 uA
+lmc6462_lmc6464,LMC6464BIM/NOPB,typ_supply_current,22.5 uA
+lmc6462_lmc6464,LMC6464BIM/NOPB,min_op_supply_volt,3.0 V
+lmc6462_lmc6464,LMC6464BIM/NOPB,max_op_supply_volt,15.5 V
+lmc6462_lmc6464,LMC6464BIM/NOPB,min_op_temp,-40
+lmc6462_lmc6464,LMC6464BIM/NOPB,max_op_temp,85
+lmc6462_lmc6464,LMC6464BIMX,part_family,N
+lmc6462_lmc6464,LMC6464BIMX,typ_gbp,50.0 kHz
+lmc6462_lmc6464,LMC6464BIMX,typ_supply_current,20.0 uA
+lmc6462_lmc6464,LMC6464BIMX,typ_supply_current,22.5 uA
+lmc6462_lmc6464,LMC6464BIMX,min_op_supply_volt,3.0 V
+lmc6462_lmc6464,LMC6464BIMX,max_op_supply_volt,15.5 V
+lmc6462_lmc6464,LMC6464BIMX,min_op_temp,-40
+lmc6462_lmc6464,LMC6464BIMX,max_op_temp,85
+lmc6462_lmc6464,LMC6464BIN,part_family,N
+lmc6462_lmc6464,LMC6464BIN,typ_gbp,50.0 kHz
+lmc6462_lmc6464,LMC6464BIN,typ_supply_current,20.0 uA
+lmc6462_lmc6464,LMC6464BIN,typ_supply_current,22.5 uA
+lmc6462_lmc6464,LMC6464BIN,min_op_supply_volt,3.0 V
+lmc6462_lmc6464,LMC6464BIN,max_op_supply_volt,15.5 V
+lmc6462_lmc6464,LMC6464BIN,min_op_temp,-40
+lmc6462_lmc6464,LMC6464BIN,max_op_temp,85
+lmc6462_lmc6464,LMC6464BIN/NOPB,part_family,N
+lmc6462_lmc6464,LMC6464BIN/NOPB,typ_gbp,50.0 kHz
+lmc6462_lmc6464,LMC6464BIN/NOPB,typ_supply_current,20.0 uA
+lmc6462_lmc6464,LMC6464BIN/NOPB,typ_supply_current,22.5 uA
+lmc6462_lmc6464,LMC6464BIN/NOPB,min_op_supply_volt,3.0 V
+lmc6462_lmc6464,LMC6464BIN/NOPB,max_op_supply_volt,15.5 V
+lmc6462_lmc6464,LMC6464BIN/NOPB,min_op_temp,-40
+lmc6462_lmc6464,LMC6464BIN/NOPB,max_op_temp,85
+lme49721,LME49721,part_family,Y
+lme49721,LME49721,typ_gbp,20.0 MHz
+lme49721,LME49721,typ_supply_current,2.15 mA
+lme49721,LME49721,min_op_supply_volt,2.2 V
+lme49721,LME49721,max_op_supply_volt,5.5 V
+lme49721,LME49721,min_op_temp,-40
+lme49721,LME49721,max_op_temp,85
+lme49721,LME49721MA/NOPB,part_family,N
+lme49721,LME49721MA/NOPB,typ_gbp,20.0 MHz
+lme49721,LME49721MA/NOPB,typ_supply_current,2.15 mA
+lme49721,LME49721MA/NOPB,min_op_supply_volt,2.2 V
+lme49721,LME49721MA/NOPB,max_op_supply_volt,5.5 V
+lme49721,LME49721MA/NOPB,min_op_temp,-40
+lme49721,LME49721MA/NOPB,max_op_temp,85
+lme49721,LME49721MAX/NOPB,part_family,N
+lme49721,LME49721MAX/NOPB,typ_gbp,20.0 MHz
+lme49721,LME49721MAX/NOPB,typ_supply_current,2.15 mA
+lme49721,LME49721MAX/NOPB,min_op_supply_volt,2.2 V
+lme49721,LME49721MAX/NOPB,max_op_supply_volt,5.5 V
+lme49721,LME49721MAX/NOPB,min_op_temp,-40
+lme49721,LME49721MAX/NOPB,max_op_temp,85
+lmh6640,LMH6640,part_family,Y
+lmh6640,LMH6640,typ_gbp,59.0 MHz
+lmh6640,LMH6640,typ_gbp,62.0 MHz
+lmh6640,LMH6640,typ_supply_current,3.7 mA
+lmh6640,LMH6640,typ_supply_current,4.0 mA
+lmh6640,LMH6640,min_op_supply_volt,4.5 V
+lmh6640,LMH6640,max_op_supply_volt,16 V
+lmh6640,LMH6640,min_op_temp,-40
+lmh6640,LMH6640,max_op_temp,85
+lmh6640,LMH6640MF/NOPB,part_family,N
+lmh6640,LMH6640MF/NOPB,typ_gbp,59.0 MHz
+lmh6640,LMH6640MF/NOPB,typ_gbp,62.0 MHz
+lmh6640,LMH6640MF/NOPB,typ_supply_current,3.7 mA
+lmh6640,LMH6640MF/NOPB,typ_supply_current,4.0 mA
+lmh6640,LMH6640MF/NOPB,min_op_supply_volt,4.5 V
+lmh6640,LMH6640MF/NOPB,max_op_supply_volt,16 V
+lmh6640,LMH6640MF/NOPB,min_op_temp,-40
+lmh6640,LMH6640MF/NOPB,max_op_temp,85
+lmh6640,LMH6640MFX/NOPB,part_family,N
+lmh6640,LMH6640MFX/NOPB,typ_gbp,59.0 MHz
+lmh6640,LMH6640MFX/NOPB,typ_gbp,62.0 MHz
+lmh6640,LMH6640MFX/NOPB,typ_supply_current,3.7 mA
+lmh6640,LMH6640MFX/NOPB,typ_supply_current,4.0 mA
+lmh6640,LMH6640MFX/NOPB,min_op_supply_volt,4.5 V
+lmh6640,LMH6640MFX/NOPB,max_op_supply_volt,16 V
+lmh6640,LMH6640MFX/NOPB,min_op_temp,-40
+lmh6640,LMH6640MFX/NOPB,max_op_temp,85
+lmh6682,LMH6682,part_family,Y
+lmh6682,LMH6682,typ_supply_current,6.5 mA
+lmh6682,LMH6682,min_op_supply_volt,3 V
+lmh6682,LMH6682,max_op_supply_volt,12 V
+lmh6682,LMH6682,min_op_temp,-40
+lmh6682,LMH6682,max_op_temp,85
+lmh6682,LMH6682MA/NOPB,part_family,N
+lmh6682,LMH6682MA/NOPB,typ_supply_current,6.5 mA
+lmh6682,LMH6682MA/NOPB,min_op_supply_volt,3 V
+lmh6682,LMH6682MA/NOPB,max_op_supply_volt,12 V
+lmh6682,LMH6682MA/NOPB,min_op_temp,-40
+lmh6682,LMH6682MA/NOPB,max_op_temp,85
+lmh6682,LMH6682MAX/NOPB,part_family,N
+lmh6682,LMH6682MAX/NOPB,typ_supply_current,6.5 mA
+lmh6682,LMH6682MAX/NOPB,min_op_supply_volt,3 V
+lmh6682,LMH6682MAX/NOPB,max_op_supply_volt,12 V
+lmh6682,LMH6682MAX/NOPB,min_op_temp,-40
+lmh6682,LMH6682MAX/NOPB,max_op_temp,85
+lmh6682,LMH6682MM/NOPB,part_family,N
+lmh6682,LMH6682MM/NOPB,typ_supply_current,6.5 mA
+lmh6682,LMH6682MM/NOPB,min_op_supply_volt,3 V
+lmh6682,LMH6682MM/NOPB,max_op_supply_volt,12 V
+lmh6682,LMH6682MM/NOPB,min_op_temp,-40
+lmh6682,LMH6682MM/NOPB,max_op_temp,85
+lmh6682,LMH6682MMX/NOPB,part_family,N
+lmh6682,LMH6682MMX/NOPB,typ_supply_current,6.5 mA
+lmh6682,LMH6682MMX/NOPB,min_op_supply_volt,3 V
+lmh6682,LMH6682MMX/NOPB,max_op_supply_volt,12 V
+lmh6682,LMH6682MMX/NOPB,min_op_temp,-40
+lmh6682,LMH6682MMX/NOPB,max_op_temp,85
+lmh6682,LMH6683,part_family,Y
+lmh6682,LMH6683,typ_supply_current,6.5 mA
+lmh6682,LMH6683,min_op_supply_volt,3 V
+lmh6682,LMH6683,max_op_supply_volt,12 V
+lmh6682,LMH6683,min_op_temp,-40
+lmh6682,LMH6683,max_op_temp,85
+lmh6682,LMH6683MA/NOPB,part_family,N
+lmh6682,LMH6683MA/NOPB,typ_supply_current,6.5 mA
+lmh6682,LMH6683MA/NOPB,min_op_supply_volt,3 V
+lmh6682,LMH6683MA/NOPB,max_op_supply_volt,12 V
+lmh6682,LMH6683MA/NOPB,min_op_temp,-40
+lmh6682,LMH6683MA/NOPB,max_op_temp,85
+lmh6682,LMH6683MAX/NOPB,part_family,N
+lmh6682,LMH6683MAX/NOPB,typ_supply_current,6.5 mA
+lmh6682,LMH6683MAX/NOPB,min_op_supply_volt,3 V
+lmh6682,LMH6683MAX/NOPB,max_op_supply_volt,12 V
+lmh6682,LMH6683MAX/NOPB,min_op_temp,-40
+lmh6682,LMH6683MAX/NOPB,max_op_temp,85
+lmh6682,LMH6683MT/NOPB,part_family,N
+lmh6682,LMH6683MT/NOPB,typ_supply_current,6.5 mA
+lmh6682,LMH6683MT/NOPB,min_op_supply_volt,3 V
+lmh6682,LMH6683MT/NOPB,max_op_supply_volt,12 V
+lmh6682,LMH6683MT/NOPB,min_op_temp,-40
+lmh6682,LMH6683MT/NOPB,max_op_temp,85
+lmh6682,LMH6683MTX/NOPB,part_family,N
+lmh6682,LMH6683MTX/NOPB,typ_supply_current,6.5 mA
+lmh6682,LMH6683MTX/NOPB,min_op_supply_volt,3 V
+lmh6682,LMH6683MTX/NOPB,max_op_supply_volt,12 V
+lmh6682,LMH6683MTX/NOPB,min_op_temp,-40
+lmh6682,LMH6683MTX/NOPB,max_op_temp,85
+lmv641,LMV641,part_family,Y
+lmv641,LMV641,typ_gbp,10.0 MHz
+lmv641,LMV641,typ_supply_current,138.0 uA
+lmv641,LMV641,typ_supply_current,158.0 uA
+lmv641,LMV641,min_op_supply_volt,2.7 V
+lmv641,LMV641,max_op_supply_volt,12 V
+lmv641,LMV641,min_op_temp,-40
+lmv641,LMV641,max_op_temp,125
+lmv641,LMV641MA/NOPB,part_family,N
+lmv641,LMV641MA/NOPB,typ_gbp,10.0 MHz
+lmv641,LMV641MA/NOPB,typ_supply_current,138.0 uA
+lmv641,LMV641MA/NOPB,typ_supply_current,158.0 uA
+lmv641,LMV641MA/NOPB,min_op_supply_volt,2.7 V
+lmv641,LMV641MA/NOPB,max_op_supply_volt,12 V
+lmv641,LMV641MA/NOPB,min_op_temp,-40
+lmv641,LMV641MA/NOPB,max_op_temp,125
+lmv641,LMV641MAE/NOPB,part_family,N
+lmv641,LMV641MAE/NOPB,typ_gbp,10.0 MHz
+lmv641,LMV641MAE/NOPB,typ_supply_current,138.0 uA
+lmv641,LMV641MAE/NOPB,typ_supply_current,158.0 uA
+lmv641,LMV641MAE/NOPB,min_op_supply_volt,2.7 V
+lmv641,LMV641MAE/NOPB,max_op_supply_volt,12 V
+lmv641,LMV641MAE/NOPB,min_op_temp,-40
+lmv641,LMV641MAE/NOPB,max_op_temp,125
+lmv641,LMV641MAX/NOPB,part_family,N
+lmv641,LMV641MAX/NOPB,typ_gbp,10.0 MHz
+lmv641,LMV641MAX/NOPB,typ_supply_current,138.0 uA
+lmv641,LMV641MAX/NOPB,typ_supply_current,158.0 uA
+lmv641,LMV641MAX/NOPB,min_op_supply_volt,2.7 V
+lmv641,LMV641MAX/NOPB,max_op_supply_volt,12 V
+lmv641,LMV641MAX/NOPB,min_op_temp,-40
+lmv641,LMV641MAX/NOPB,max_op_temp,125
+lmv641,LMV641MF/NOPB,part_family,N
+lmv641,LMV641MF/NOPB,typ_gbp,10.0 MHz
+lmv641,LMV641MF/NOPB,typ_supply_current,138.0 uA
+lmv641,LMV641MF/NOPB,typ_supply_current,158.0 uA
+lmv641,LMV641MF/NOPB,min_op_supply_volt,2.7 V
+lmv641,LMV641MF/NOPB,max_op_supply_volt,12 V
+lmv641,LMV641MF/NOPB,min_op_temp,-40
+lmv641,LMV641MF/NOPB,max_op_temp,125
+lmv641,LMV641MFE/NOPB,part_family,N
+lmv641,LMV641MFE/NOPB,typ_gbp,10.0 MHz
+lmv641,LMV641MFE/NOPB,typ_supply_current,138.0 uA
+lmv641,LMV641MFE/NOPB,typ_supply_current,158.0 uA
+lmv641,LMV641MFE/NOPB,min_op_supply_volt,2.7 V
+lmv641,LMV641MFE/NOPB,max_op_supply_volt,12 V
+lmv641,LMV641MFE/NOPB,min_op_temp,-40
+lmv641,LMV641MFE/NOPB,max_op_temp,125
+lmv641,LMV641MFX/NOPB,part_family,N
+lmv641,LMV641MFX/NOPB,typ_gbp,10.0 MHz
+lmv641,LMV641MFX/NOPB,typ_supply_current,138.0 uA
+lmv641,LMV641MFX/NOPB,typ_supply_current,158.0 uA
+lmv641,LMV641MFX/NOPB,min_op_supply_volt,2.7 V
+lmv641,LMV641MFX/NOPB,max_op_supply_volt,12 V
+lmv641,LMV641MFX/NOPB,min_op_temp,-40
+lmv641,LMV641MFX/NOPB,max_op_temp,125
+lmv641,LMV641MG/NOPB,part_family,N
+lmv641,LMV641MG/NOPB,typ_gbp,10.0 MHz
+lmv641,LMV641MG/NOPB,typ_supply_current,138.0 uA
+lmv641,LMV641MG/NOPB,typ_supply_current,158.0 uA
+lmv641,LMV641MG/NOPB,min_op_supply_volt,2.7 V
+lmv641,LMV641MG/NOPB,max_op_supply_volt,12 V
+lmv641,LMV641MG/NOPB,min_op_temp,-40
+lmv641,LMV641MG/NOPB,max_op_temp,125
+lmv641,LMV641MGE/NOPB,part_family,N
+lmv641,LMV641MGE/NOPB,typ_gbp,10.0 MHz
+lmv641,LMV641MGE/NOPB,typ_supply_current,138.0 uA
+lmv641,LMV641MGE/NOPB,typ_supply_current,158.0 uA
+lmv641,LMV641MGE/NOPB,min_op_supply_volt,2.7 V
+lmv641,LMV641MGE/NOPB,max_op_supply_volt,12 V
+lmv641,LMV641MGE/NOPB,min_op_temp,-40
+lmv641,LMV641MGE/NOPB,max_op_temp,125
+lmv641,LMV641MGX/NOPB,part_family,N
+lmv641,LMV641MGX/NOPB,typ_gbp,10.0 MHz
+lmv641,LMV641MGX/NOPB,typ_supply_current,138.0 uA
+lmv641,LMV641MGX/NOPB,typ_supply_current,158.0 uA
+lmv641,LMV641MGX/NOPB,min_op_supply_volt,2.7 V
+lmv641,LMV641MGX/NOPB,max_op_supply_volt,12 V
+lmv641,LMV641MGX/NOPB,min_op_temp,-40
+lmv641,LMV641MGX/NOPB,max_op_temp,125
+lpv801,LPV801,part_family,Y
+lpv801,LPV801,typ_gbp,8.0 kHz
+lpv801,LPV801,typ_supply_current,450.0 nA
+lpv801,LPV801,min_op_supply_volt,1.6 V
+lpv801,LPV801,max_op_supply_volt,5.5 V
+lpv801,LPV801,min_op_temp,-40
+lpv801,LPV801,max_op_temp,125
+lpv801,LPV801DBVR,part_family,N
+lpv801,LPV801DBVR,typ_gbp,8.0 kHz
+lpv801,LPV801DBVR,typ_supply_current,450.0 nA
+lpv801,LPV801DBVR,min_op_supply_volt,1.6 V
+lpv801,LPV801DBVR,max_op_supply_volt,5.5 V
+lpv801,LPV801DBVR,min_op_temp,-40
+lpv801,LPV801DBVR,max_op_temp,125
+lpv801,LPV801DBVT,part_family,N
+lpv801,LPV801DBVT,typ_gbp,8.0 kHz
+lpv801,LPV801DBVT,typ_supply_current,450.0 nA
+lpv801,LPV801DBVT,min_op_supply_volt,1.6 V
+lpv801,LPV801DBVT,max_op_supply_volt,5.5 V
+lpv801,LPV801DBVT,min_op_temp,-40
+lpv801,LPV801DBVT,max_op_temp,125
+lpv801,LPV802,part_family,Y
+lpv801,LPV802,typ_gbp,8.0 kHz
+lpv801,LPV802,typ_supply_current,320.0 nA
+lpv801,LPV802,min_op_supply_volt,1.6 V
+lpv801,LPV802,max_op_supply_volt,5.5 V
+lpv801,LPV802,min_op_temp,-40
+lpv801,LPV802,max_op_temp,125
+lpv801,LPV802DGKR,part_family,N
+lpv801,LPV802DGKR,typ_gbp,8.0 kHz
+lpv801,LPV802DGKR,typ_supply_current,320.0 nA
+lpv801,LPV802DGKR,min_op_supply_volt,1.6 V
+lpv801,LPV802DGKR,max_op_supply_volt,5.5 V
+lpv801,LPV802DGKR,min_op_temp,-40
+lpv801,LPV802DGKR,max_op_temp,125
+lpv801,LPV802DGKT,part_family,N
+lpv801,LPV802DGKT,typ_gbp,8.0 kHz
+lpv801,LPV802DGKT,typ_supply_current,320.0 nA
+lpv801,LPV802DGKT,min_op_supply_volt,1.6 V
+lpv801,LPV802DGKT,max_op_supply_volt,5.5 V
+lpv801,LPV802DGKT,min_op_temp,-40
+lpv801,LPV802DGKT,max_op_temp,125
+max4289,MAX4289,part_family,Y
+max4289,MAX4289,typ_gbp,17.0 kHz
+max4289,MAX4289,typ_supply_current,9.0 uA
+max4289,MAX4289,typ_supply_current,12.0 uA
+max4289,MAX4289,typ_supply_current,18.0 uA
+max4289,MAX4289,min_op_supply_volt,1.0 V
+max4289,MAX4289,max_op_supply_volt,5.5 V
+max4289,MAX4289,min_op_temp,-40
+max4289,MAX4289,max_op_temp,85
+max4289,MAX4289EUT-T,part_family,N
+max4289,MAX4289EUT-T,typ_gbp,17.0 kHz
+max4289,MAX4289EUT-T,typ_supply_current,9.0 uA
+max4289,MAX4289EUT-T,typ_supply_current,12.0 uA
+max4289,MAX4289EUT-T,typ_supply_current,18.0 uA
+max4289,MAX4289EUT-T,min_op_supply_volt,1.0 V
+max4289,MAX4289EUT-T,max_op_supply_volt,5.5 V
+max4289,MAX4289EUT-T,min_op_temp,-40
+max4289,MAX4289EUT-T,max_op_temp,85
+max4289,MAX4289ESA,part_family,N
+max4289,MAX4289ESA,typ_gbp,17.0 kHz
+max4289,MAX4289ESA,typ_supply_current,9.0 uA
+max4289,MAX4289ESA,typ_supply_current,12.0 uA
+max4289,MAX4289ESA,typ_supply_current,18.0 uA
+max4289,MAX4289ESA,min_op_supply_volt,1.0 V
+max4289,MAX4289ESA,max_op_supply_volt,5.5 V
+max4289,MAX4289ESA,min_op_temp,-40
+max4289,MAX4289ESA,max_op_temp,85
+max44244-max44248,MAX44244,part_family,Y
+max44244-max44248,MAX44244,typ_gbp,1.0 MHz
+max44244-max44248,MAX44244,typ_supply_current,100.0 uA
+max44244-max44248,MAX44244,min_op_supply_volt,2.7 V
+max44244-max44248,MAX44244,max_op_supply_volt,36 V
+max44244-max44248,MAX44244,min_op_temp,-40
+max44244-max44248,MAX44244,max_op_temp,125
+max44244-max44248,MAX44244AUK+,part_family,N
+max44244-max44248,MAX44244AUK+,typ_gbp,1.0 MHz
+max44244-max44248,MAX44244AUK+,typ_supply_current,100.0 uA
+max44244-max44248,MAX44244AUK+,min_op_supply_volt,2.7 V
+max44244-max44248,MAX44244AUK+,max_op_supply_volt,36 V
+max44244-max44248,MAX44244AUK+,min_op_temp,-40
+max44244-max44248,MAX44244AUK+,max_op_temp,125
+max44244-max44248,MAX44244AUA+,part_family,N
+max44244-max44248,MAX44244AUA+,typ_gbp,1.0 MHz
+max44244-max44248,MAX44244AUA+,typ_supply_current,100.0 uA
+max44244-max44248,MAX44244AUA+,min_op_supply_volt,2.7 V
+max44244-max44248,MAX44244AUA+,max_op_supply_volt,36 V
+max44244-max44248,MAX44244AUA+,min_op_temp,-40
+max44244-max44248,MAX44244AUA+,max_op_temp,125
+max44244-max44248,MAX44245,part_family,Y
+max44244-max44248,MAX44245,typ_gbp,1.0 MHz
+max44244-max44248,MAX44245,typ_supply_current,90.0 uA
+max44244-max44248,MAX44245,min_op_supply_volt,2.7 V
+max44244-max44248,MAX44245,max_op_supply_volt,36 V
+max44244-max44248,MAX44245,min_op_temp,-40
+max44244-max44248,MAX44245,max_op_temp,125
+max44244-max44248,MAX44245ASD+,part_family,N
+max44244-max44248,MAX44245ASD+,typ_gbp,1.0 MHz
+max44244-max44248,MAX44245ASD+,typ_supply_current,90.0 uA
+max44244-max44248,MAX44245ASD+,min_op_supply_volt,2.7 V
+max44244-max44248,MAX44245ASD+,max_op_supply_volt,36 V
+max44244-max44248,MAX44245ASD+,min_op_temp,-40
+max44244-max44248,MAX44245ASD+,max_op_temp,125
+max44244-max44248,MAX44245AUD+,part_family,N
+max44244-max44248,MAX44245AUD+,typ_gbp,1.0 MHz
+max44244-max44248,MAX44245AUD+,typ_supply_current,90.0 uA
+max44244-max44248,MAX44245AUD+,min_op_supply_volt,2.7 V
+max44244-max44248,MAX44245AUD+,max_op_supply_volt,36 V
+max44244-max44248,MAX44245AUD+,min_op_temp,-40
+max44244-max44248,MAX44245AUD+,max_op_temp,125
+max44244-max44248,MAX44248,part_family,Y
+max44244-max44248,MAX44248,typ_gbp,1.0 MHz
+max44244-max44248,MAX44248,typ_supply_current,90.0 uA
+max44244-max44248,MAX44248,min_op_supply_volt,2.7 V
+max44244-max44248,MAX44248,max_op_supply_volt,36 V
+max44244-max44248,MAX44248,min_op_temp,-40
+max44244-max44248,MAX44248,max_op_temp,125
+max44244-max44248,MAX44248AUA+,part_family,N
+max44244-max44248,MAX44248AUA+,typ_gbp,1.0 MHz
+max44244-max44248,MAX44248AUA+,typ_supply_current,90.0 uA
+max44244-max44248,MAX44248AUA+,min_op_supply_volt,2.7 V
+max44244-max44248,MAX44248AUA+,max_op_supply_volt,36 V
+max44244-max44248,MAX44248AUA+,min_op_temp,-40
+max44244-max44248,MAX44248AUA+,max_op_temp,125
+max44244-max44248,MAX44248ASA+,part_family,N
+max44244-max44248,MAX44248ASA+,typ_gbp,1.0 MHz
+max44244-max44248,MAX44248ASA+,typ_supply_current,90.0 uA
+max44244-max44248,MAX44248ASA+,min_op_supply_volt,2.7 V
+max44244-max44248,MAX44248ASA+,max_op_supply_volt,36 V
+max44244-max44248,MAX44248ASA+,min_op_temp,-40
+max44244-max44248,MAX44248ASA+,max_op_temp,125
+max44260-max44263,MAX44259,part_family,Y
+max44260-max44263,MAX44259,typ_gbp,15.0 MHz
+max44260-max44263,MAX44259,typ_supply_current,750.0 uA
+max44260-max44263,MAX44259,min_op_supply_volt,1.8 V
+max44260-max44263,MAX44259,max_op_supply_volt,5.5 V
+max44260-max44263,MAX44259,min_op_temp,-40
+max44260-max44263,MAX44259,max_op_temp,125
+max44260-max44263,MAX44259AUK+,part_family,N
+max44260-max44263,MAX44259AUK+,typ_gbp,15.0 MHz
+max44260-max44263,MAX44259AUK+,typ_supply_current,750.0 uA
+max44260-max44263,MAX44259AUK+,min_op_supply_volt,1.8 V
+max44260-max44263,MAX44259AUK+,max_op_supply_volt,5.5 V
+max44260-max44263,MAX44259AUK+,min_op_temp,-40
+max44260-max44263,MAX44259AUK+,max_op_temp,125
+max44260-max44263,MAX44260,part_family,Y
+max44260-max44263,MAX44260,typ_gbp,15.0 MHz
+max44260-max44263,MAX44260,typ_supply_current,750.0 uA
+max44260-max44263,MAX44260,min_op_supply_volt,1.8 V
+max44260-max44263,MAX44260,max_op_supply_volt,5.5 V
+max44260-max44263,MAX44260,min_op_temp,-40
+max44260-max44263,MAX44260,max_op_temp,125
+max44260-max44263,MAX44260AXT+,part_family,N
+max44260-max44263,MAX44260AXT+,typ_gbp,15.0 MHz
+max44260-max44263,MAX44260AXT+,typ_supply_current,750.0 uA
+max44260-max44263,MAX44260AXT+,min_op_supply_volt,1.8 V
+max44260-max44263,MAX44260AXT+,max_op_supply_volt,5.5 V
+max44260-max44263,MAX44260AXT+,min_op_temp,-40
+max44260-max44263,MAX44260AXT+,max_op_temp,125
+max44260-max44263,MAX44260AYT+,part_family,N
+max44260-max44263,MAX44260AYT+,typ_gbp,15.0 MHz
+max44260-max44263,MAX44260AYT+,typ_supply_current,750.0 uA
+max44260-max44263,MAX44260AYT+,min_op_supply_volt,1.8 V
+max44260-max44263,MAX44260AYT+,max_op_supply_volt,5.5 V
+max44260-max44263,MAX44260AYT+,min_op_temp,-40
+max44260-max44263,MAX44260AYT+,max_op_temp,125
+max44260-max44263,MAX44261,part_family,Y
+max44260-max44263,MAX44261,typ_gbp,15.0 MHz
+max44260-max44263,MAX44261,typ_supply_current,750.0 uA
+max44260-max44263,MAX44261,min_op_supply_volt,1.8 V
+max44260-max44263,MAX44261,max_op_supply_volt,5.5 V
+max44260-max44263,MAX44261,min_op_temp,-40
+max44260-max44263,MAX44261,max_op_temp,125
+max44260-max44263,MAX44261AXT+,part_family,N
+max44260-max44263,MAX44261AXT+,typ_gbp,15.0 MHz
+max44260-max44263,MAX44261AXT+,typ_supply_current,750.0 uA
+max44260-max44263,MAX44261AXT+,min_op_supply_volt,1.8 V
+max44260-max44263,MAX44261AXT+,max_op_supply_volt,5.5 V
+max44260-max44263,MAX44261AXT+,min_op_temp,-40
+max44260-max44263,MAX44261AXT+,max_op_temp,125
+max44260-max44263,MAX44263,part_family,Y
+max44260-max44263,MAX44263,typ_gbp,15.0 MHz
+max44260-max44263,MAX44263,typ_supply_current,650.0 uA
+max44260-max44263,MAX44263,min_op_supply_volt,1.8 V
+max44260-max44263,MAX44263,max_op_supply_volt,5.5 V
+max44260-max44263,MAX44263,min_op_temp,-40
+max44260-max44263,MAX44263,max_op_temp,125
+max44260-max44263,MAX44263AXA+,part_family,N
+max44260-max44263,MAX44263AXA+,typ_gbp,15.0 MHz
+max44260-max44263,MAX44263AXA+,typ_supply_current,650.0 uA
+max44260-max44263,MAX44263AXA+,min_op_supply_volt,1.8 V
+max44260-max44263,MAX44263AXA+,max_op_supply_volt,5.5 V
+max44260-max44263,MAX44263AXA+,min_op_temp,-40
+max44260-max44263,MAX44263AXA+,max_op_temp,125
+mp39u,MP39,part_family,N
+mp39u,MP39,typ_gbp,2.0 MHz
+mp39u,MP39,typ_supply_current,26.0 mA
+mp39u,MP39,min_op_supply_volt,±15 V
+mp39u,MP39,max_op_supply_volt,±50 V
+mp39u,MP39,min_op_temp,-40
+mp39u,MP39,max_op_temp,85
+mp39u,MP39A,part_family,N
+mp39u,MP39A,typ_gbp,2.0 MHz
+mp39u,MP39A,typ_supply_current,26.0 mA
+mp39u,MP39A,min_op_supply_volt,±15 V
+mp39u,MP39A,max_op_supply_volt,±50 V
+mp39u,MP39A,min_op_temp,-40
+mp39u,MP39A,max_op_temp,85
+muses01,MUSES01,part_family,N
+muses01,MUSES01,typ_gbp,3.3 MHz
+muses01,MUSES01,typ_supply_current,8.5 mA
+muses01,MUSES01,min_op_supply_volt,±9 V
+muses01,MUSES01,max_op_supply_volt,±16 V
+muses01,MUSES01,min_op_temp,-40
+muses01,MUSES01,max_op_temp,85
+onet4201pa,ONET4201PA,part_family,Y
+onet4201pa,ONET4201PA,typ_supply_current,35.0 mA
+onet4201pa,ONET4201PA,min_op_supply_volt,3 V
+onet4201pa,ONET4201PA,max_op_supply_volt,3.6 V
+onet4201pa,ONET4201PA,min_op_temp,-40
+onet4201pa,ONET4201PA,max_op_temp,85
+onet4201pa,ONET4201PARGTR,part_family,N
+onet4201pa,ONET4201PARGTR,typ_supply_current,35.0 mA
+onet4201pa,ONET4201PARGTR,min_op_supply_volt,3 V
+onet4201pa,ONET4201PARGTR,max_op_supply_volt,3.6 V
+onet4201pa,ONET4201PARGTR,min_op_temp,-40
+onet4201pa,ONET4201PARGTR,max_op_temp,85
+onet4201pa,ONET4201PARGTRG4,part_family,N
+onet4201pa,ONET4201PARGTRG4,typ_supply_current,35.0 mA
+onet4201pa,ONET4201PARGTRG4,min_op_supply_volt,3 V
+onet4201pa,ONET4201PARGTRG4,max_op_supply_volt,3.6 V
+onet4201pa,ONET4201PARGTRG4,min_op_temp,-40
+onet4201pa,ONET4201PARGTRG4,max_op_temp,85
+onet4201pa,ONET4201PARGTT,part_family,N
+onet4201pa,ONET4201PARGTT,typ_supply_current,35.0 mA
+onet4201pa,ONET4201PARGTT,min_op_supply_volt,3 V
+onet4201pa,ONET4201PARGTT,max_op_supply_volt,3.6 V
+onet4201pa,ONET4201PARGTT,min_op_temp,-40
+onet4201pa,ONET4201PARGTT,max_op_temp,85
+onet4201pa,ONET4201PARGTTG4,part_family,N
+onet4201pa,ONET4201PARGTTG4,typ_supply_current,35.0 mA
+onet4201pa,ONET4201PARGTTG4,min_op_supply_volt,3 V
+onet4201pa,ONET4201PARGTTG4,max_op_supply_volt,3.6 V
+onet4201pa,ONET4201PARGTTG4,min_op_temp,-40
+onet4201pa,ONET4201PARGTTG4,max_op_temp,85
+opa1654,OPA1652,part_family,Y
+opa1654,OPA1652,typ_gbp,18.0 MHz
+opa1654,OPA1652,typ_supply_current,2.0 mA
+opa1654,OPA1652,min_op_supply_volt,4.5 V
+opa1654,OPA1652,min_op_supply_volt,±2.25 V
+opa1654,OPA1652,max_op_supply_volt,36 V
+opa1654,OPA1652,max_op_supply_volt,±18 V
+opa1654,OPA1652,min_op_temp,-40
+opa1654,OPA1652,max_op_temp,85
+opa1654,OPA1652AID,part_family,N
+opa1654,OPA1652AID,typ_gbp,18.0 MHz
+opa1654,OPA1652AID,typ_supply_current,2.0 mA
+opa1654,OPA1652AID,min_op_supply_volt,4.5 V
+opa1654,OPA1652AID,min_op_supply_volt,±2.25 V
+opa1654,OPA1652AID,max_op_supply_volt,36 V
+opa1654,OPA1652AID,max_op_supply_volt,±18 V
+opa1654,OPA1652AID,min_op_temp,-40
+opa1654,OPA1652AID,max_op_temp,85
+opa1654,OPA1652AIDGK,part_family,N
+opa1654,OPA1652AIDGK,typ_gbp,18.0 MHz
+opa1654,OPA1652AIDGK,typ_supply_current,2.0 mA
+opa1654,OPA1652AIDGK,min_op_supply_volt,4.5 V
+opa1654,OPA1652AIDGK,min_op_supply_volt,±2.25 V
+opa1654,OPA1652AIDGK,max_op_supply_volt,36 V
+opa1654,OPA1652AIDGK,max_op_supply_volt,±18 V
+opa1654,OPA1652AIDGK,min_op_temp,-40
+opa1654,OPA1652AIDGK,max_op_temp,85
+opa1654,OPA1652AIDR,part_family,N
+opa1654,OPA1652AIDR,typ_gbp,18.0 MHz
+opa1654,OPA1652AIDR,typ_supply_current,2.0 mA
+opa1654,OPA1652AIDR,min_op_supply_volt,4.5 V
+opa1654,OPA1652AIDR,min_op_supply_volt,±2.25 V
+opa1654,OPA1652AIDR,max_op_supply_volt,36 V
+opa1654,OPA1652AIDR,max_op_supply_volt,±18 V
+opa1654,OPA1652AIDR,min_op_temp,-40
+opa1654,OPA1652AIDR,max_op_temp,85
+opa1654,OPA1652AIDRGR,part_family,N
+opa1654,OPA1652AIDRGR,typ_gbp,18.0 MHz
+opa1654,OPA1652AIDRGR,typ_supply_current,2.0 mA
+opa1654,OPA1652AIDRGR,min_op_supply_volt,4.5 V
+opa1654,OPA1652AIDRGR,min_op_supply_volt,±2.25 V
+opa1654,OPA1652AIDRGR,max_op_supply_volt,36 V
+opa1654,OPA1652AIDRGR,max_op_supply_volt,±18 V
+opa1654,OPA1652AIDRGR,min_op_temp,-40
+opa1654,OPA1652AIDRGR,max_op_temp,85
+opa1654,OPA1652AIDRGT,part_family,N
+opa1654,OPA1652AIDRGT,typ_gbp,18.0 MHz
+opa1654,OPA1652AIDRGT,typ_supply_current,2.0 mA
+opa1654,OPA1652AIDRGT,min_op_supply_volt,4.5 V
+opa1654,OPA1652AIDRGT,min_op_supply_volt,±2.25 V
+opa1654,OPA1652AIDRGT,max_op_supply_volt,36 V
+opa1654,OPA1652AIDRGT,max_op_supply_volt,±18 V
+opa1654,OPA1652AIDRGT,min_op_temp,-40
+opa1654,OPA1652AIDRGT,max_op_temp,85
+opa1654,OPA1652AIDGKR,part_family,N
+opa1654,OPA1652AIDGKR,typ_gbp,18.0 MHz
+opa1654,OPA1652AIDGKR,typ_supply_current,2.0 mA
+opa1654,OPA1652AIDGKR,min_op_supply_volt,4.5 V
+opa1654,OPA1652AIDGKR,min_op_supply_volt,±2.25 V
+opa1654,OPA1652AIDGKR,max_op_supply_volt,36 V
+opa1654,OPA1652AIDGKR,max_op_supply_volt,±18 V
+opa1654,OPA1652AIDGKR,min_op_temp,-40
+opa1654,OPA1652AIDGKR,max_op_temp,85
+opa1654,OPA1654,part_family,Y
+opa1654,OPA1654,typ_gbp,18.0 MHz
+opa1654,OPA1654,typ_supply_current,2.0 mA
+opa1654,OPA1654,min_op_supply_volt,4.5 V
+opa1654,OPA1654,min_op_supply_volt,±2.25 V
+opa1654,OPA1654,max_op_supply_volt,36 V
+opa1654,OPA1654,max_op_supply_volt,±18 V
+opa1654,OPA1654,min_op_temp,-40
+opa1654,OPA1654,max_op_temp,85
+opa1654,OPA1654AID,part_family,N
+opa1654,OPA1654AID,typ_gbp,18.0 MHz
+opa1654,OPA1654AID,typ_supply_current,2.0 mA
+opa1654,OPA1654AID,min_op_supply_volt,4.5 V
+opa1654,OPA1654AID,min_op_supply_volt,±2.25 V
+opa1654,OPA1654AID,max_op_supply_volt,36 V
+opa1654,OPA1654AID,max_op_supply_volt,±18 V
+opa1654,OPA1654AID,min_op_temp,-40
+opa1654,OPA1654AID,max_op_temp,85
+opa1654,OPA1654AIDR,part_family,N
+opa1654,OPA1654AIDR,typ_gbp,18.0 MHz
+opa1654,OPA1654AIDR,typ_supply_current,2.0 mA
+opa1654,OPA1654AIDR,min_op_supply_volt,4.5 V
+opa1654,OPA1654AIDR,min_op_supply_volt,±2.25 V
+opa1654,OPA1654AIDR,max_op_supply_volt,36 V
+opa1654,OPA1654AIDR,max_op_supply_volt,±18 V
+opa1654,OPA1654AIDR,min_op_temp,-40
+opa1654,OPA1654AIDR,max_op_temp,85
+opa1654,OPA1654AIPW,part_family,N
+opa1654,OPA1654AIPW,typ_gbp,18.0 MHz
+opa1654,OPA1654AIPW,typ_supply_current,2.0 mA
+opa1654,OPA1654AIPW,min_op_supply_volt,4.5 V
+opa1654,OPA1654AIPW,min_op_supply_volt,±2.25 V
+opa1654,OPA1654AIPW,max_op_supply_volt,36 V
+opa1654,OPA1654AIPW,max_op_supply_volt,±18 V
+opa1654,OPA1654AIPW,min_op_temp,-40
+opa1654,OPA1654AIPW,max_op_temp,85
+opa1654,OPA1654AIPWR,part_family,N
+opa1654,OPA1654AIPWR,typ_gbp,18.0 MHz
+opa1654,OPA1654AIPWR,typ_supply_current,2.0 mA
+opa1654,OPA1654AIPWR,min_op_supply_volt,4.5 V
+opa1654,OPA1654AIPWR,min_op_supply_volt,±2.25 V
+opa1654,OPA1654AIPWR,max_op_supply_volt,36 V
+opa1654,OPA1654AIPWR,max_op_supply_volt,±18 V
+opa1654,OPA1654AIPWR,min_op_temp,-40
+opa1654,OPA1654AIPWR,max_op_temp,85
+opa191,OPA191,part_family,Y
+opa191,OPA191,typ_gbp,2.5 MHz
+opa191,OPA191,typ_supply_current,140.0 uA
+opa191,OPA191,min_op_supply_volt,4.5 V
+opa191,OPA191,min_op_supply_volt,±2.25 V
+opa191,OPA191,max_op_supply_volt,36 V
+opa191,OPA191,max_op_supply_volt,±18 V
+opa191,OPA191,min_op_temp,-40
+opa191,OPA191,max_op_temp,125
+opa191,OPA191ID,part_family,N
+opa191,OPA191ID,typ_gbp,2.5 MHz
+opa191,OPA191ID,typ_supply_current,140.0 uA
+opa191,OPA191ID,min_op_supply_volt,4.5 V
+opa191,OPA191ID,min_op_supply_volt,±2.25 V
+opa191,OPA191ID,max_op_supply_volt,36 V
+opa191,OPA191ID,max_op_supply_volt,±18 V
+opa191,OPA191ID,min_op_temp,-40
+opa191,OPA191ID,max_op_temp,125
+opa191,OPA191IDBVR,part_family,N
+opa191,OPA191IDBVR,typ_gbp,2.5 MHz
+opa191,OPA191IDBVR,typ_supply_current,140.0 uA
+opa191,OPA191IDBVR,min_op_supply_volt,4.5 V
+opa191,OPA191IDBVR,min_op_supply_volt,±2.25 V
+opa191,OPA191IDBVR,max_op_supply_volt,36 V
+opa191,OPA191IDBVR,max_op_supply_volt,±18 V
+opa191,OPA191IDBVR,min_op_temp,-40
+opa191,OPA191IDBVR,max_op_temp,125
+opa191,OPA191IDBVT,part_family,N
+opa191,OPA191IDBVT,typ_gbp,2.5 MHz
+opa191,OPA191IDBVT,typ_supply_current,140.0 uA
+opa191,OPA191IDBVT,min_op_supply_volt,4.5 V
+opa191,OPA191IDBVT,min_op_supply_volt,±2.25 V
+opa191,OPA191IDBVT,max_op_supply_volt,36 V
+opa191,OPA191IDBVT,max_op_supply_volt,±18 V
+opa191,OPA191IDBVT,min_op_temp,-40
+opa191,OPA191IDBVT,max_op_temp,125
+opa191,OPA191IDGKR,part_family,N
+opa191,OPA191IDGKR,typ_gbp,2.5 MHz
+opa191,OPA191IDGKR,typ_supply_current,140.0 uA
+opa191,OPA191IDGKR,min_op_supply_volt,4.5 V
+opa191,OPA191IDGKR,min_op_supply_volt,±2.25 V
+opa191,OPA191IDGKR,max_op_supply_volt,36 V
+opa191,OPA191IDGKR,max_op_supply_volt,±18 V
+opa191,OPA191IDGKR,min_op_temp,-40
+opa191,OPA191IDGKR,max_op_temp,125
+opa191,OPA191IDGKT,part_family,N
+opa191,OPA191IDGKT,typ_gbp,2.5 MHz
+opa191,OPA191IDGKT,typ_supply_current,140.0 uA
+opa191,OPA191IDGKT,min_op_supply_volt,4.5 V
+opa191,OPA191IDGKT,min_op_supply_volt,±2.25 V
+opa191,OPA191IDGKT,max_op_supply_volt,36 V
+opa191,OPA191IDGKT,max_op_supply_volt,±18 V
+opa191,OPA191IDGKT,min_op_temp,-40
+opa191,OPA191IDGKT,max_op_temp,125
+opa191,OPA191IDR,part_family,N
+opa191,OPA191IDR,typ_gbp,2.5 MHz
+opa191,OPA191IDR,typ_supply_current,140.0 uA
+opa191,OPA191IDR,min_op_supply_volt,4.5 V
+opa191,OPA191IDR,min_op_supply_volt,±2.25 V
+opa191,OPA191IDR,max_op_supply_volt,36 V
+opa191,OPA191IDR,max_op_supply_volt,±18 V
+opa191,OPA191IDR,min_op_temp,-40
+opa191,OPA191IDR,max_op_temp,125
+opa191,OPA2191,part_family,Y
+opa191,OPA2191,typ_gbp,2.5 MHz
+opa191,OPA2191,typ_supply_current,140.0 uA
+opa191,OPA2191,min_op_supply_volt,4.5 V
+opa191,OPA2191,min_op_supply_volt,±2.25 V
+opa191,OPA2191,max_op_supply_volt,36 V
+opa191,OPA2191,max_op_supply_volt,±18 V
+opa191,OPA2191,min_op_temp,-40
+opa191,OPA2191,max_op_temp,125
+opa191,OPA2191ID,part_family,N
+opa191,OPA2191ID,typ_gbp,2.5 MHz
+opa191,OPA2191ID,typ_supply_current,140.0 uA
+opa191,OPA2191ID,min_op_supply_volt,4.5 V
+opa191,OPA2191ID,min_op_supply_volt,±2.25 V
+opa191,OPA2191ID,max_op_supply_volt,36 V
+opa191,OPA2191ID,max_op_supply_volt,±18 V
+opa191,OPA2191ID,min_op_temp,-40
+opa191,OPA2191ID,max_op_temp,125
+opa191,OPA2191DR,part_family,N
+opa191,OPA2191DR,typ_gbp,2.5 MHz
+opa191,OPA2191DR,typ_supply_current,140.0 uA
+opa191,OPA2191DR,min_op_supply_volt,4.5 V
+opa191,OPA2191DR,min_op_supply_volt,±2.25 V
+opa191,OPA2191DR,max_op_supply_volt,36 V
+opa191,OPA2191DR,max_op_supply_volt,±18 V
+opa191,OPA2191DR,min_op_temp,-40
+opa191,OPA2191DR,max_op_temp,125
+opa191,OPA4191,part_family,Y
+opa191,OPA4191,typ_gbp,2.5 MHz
+opa191,OPA4191,typ_supply_current,140.0 uA
+opa191,OPA4191,min_op_supply_volt,4.5 V
+opa191,OPA4191,min_op_supply_volt,±2.25 V
+opa191,OPA4191,max_op_supply_volt,36 V
+opa191,OPA4191,max_op_supply_volt,±18 V
+opa191,OPA4191,min_op_temp,-40
+opa191,OPA4191,max_op_temp,125
+opa191,OPA4191ID,part_family,N
+opa191,OPA4191ID,typ_gbp,2.5 MHz
+opa191,OPA4191ID,typ_supply_current,140.0 uA
+opa191,OPA4191ID,min_op_supply_volt,4.5 V
+opa191,OPA4191ID,min_op_supply_volt,±2.25 V
+opa191,OPA4191ID,max_op_supply_volt,36 V
+opa191,OPA4191ID,max_op_supply_volt,±18 V
+opa191,OPA4191ID,min_op_temp,-40
+opa191,OPA4191ID,max_op_temp,125
+opa191,OPA4191DR,part_family,N
+opa191,OPA4191DR,typ_gbp,2.5 MHz
+opa191,OPA4191DR,typ_supply_current,140.0 uA
+opa191,OPA4191DR,min_op_supply_volt,4.5 V
+opa191,OPA4191DR,min_op_supply_volt,±2.25 V
+opa191,OPA4191DR,max_op_supply_volt,36 V
+opa191,OPA4191DR,max_op_supply_volt,±18 V
+opa191,OPA4191DR,min_op_temp,-40
+opa191,OPA4191DR,max_op_temp,125
+opa2317,OPA317,part_family,Y
+opa2317,OPA317,typ_gbp,300.0 kHz
+opa2317,OPA317,typ_supply_current,21.0 uA
+opa2317,OPA317,min_op_supply_volt,1.8 V
+opa2317,OPA317,min_op_supply_volt,±0.9 V
+opa2317,OPA317,max_op_supply_volt,5.5 V
+opa2317,OPA317,max_op_supply_volt,±2.25 V
+opa2317,OPA317,min_op_temp,-40
+opa2317,OPA317,max_op_temp,125
+opa2317,OPA317ID,part_family,N
+opa2317,OPA317ID,typ_gbp,300.0 kHz
+opa2317,OPA317ID,typ_supply_current,21.0 uA
+opa2317,OPA317ID,min_op_supply_volt,1.8 V
+opa2317,OPA317ID,min_op_supply_volt,±0.9 V
+opa2317,OPA317ID,max_op_supply_volt,5.5 V
+opa2317,OPA317ID,max_op_supply_volt,±2.25 V
+opa2317,OPA317ID,min_op_temp,-40
+opa2317,OPA317ID,max_op_temp,125
+opa2317,OPA317IDBVR,part_family,N
+opa2317,OPA317IDBVR,typ_gbp,300.0 kHz
+opa2317,OPA317IDBVR,typ_supply_current,21.0 uA
+opa2317,OPA317IDBVR,min_op_supply_volt,1.8 V
+opa2317,OPA317IDBVR,min_op_supply_volt,±0.9 V
+opa2317,OPA317IDBVR,max_op_supply_volt,5.5 V
+opa2317,OPA317IDBVR,max_op_supply_volt,±2.25 V
+opa2317,OPA317IDBVR,min_op_temp,-40
+opa2317,OPA317IDBVR,max_op_temp,125
+opa2317,OPA317IDBVT,part_family,N
+opa2317,OPA317IDBVT,typ_gbp,300.0 kHz
+opa2317,OPA317IDBVT,typ_supply_current,21.0 uA
+opa2317,OPA317IDBVT,min_op_supply_volt,1.8 V
+opa2317,OPA317IDBVT,min_op_supply_volt,±0.9 V
+opa2317,OPA317IDBVT,max_op_supply_volt,5.5 V
+opa2317,OPA317IDBVT,max_op_supply_volt,±2.25 V
+opa2317,OPA317IDBVT,min_op_temp,-40
+opa2317,OPA317IDBVT,max_op_temp,125
+opa2317,OPA317IDCKR,part_family,N
+opa2317,OPA317IDCKR,typ_gbp,300.0 kHz
+opa2317,OPA317IDCKR,typ_supply_current,21.0 uA
+opa2317,OPA317IDCKR,min_op_supply_volt,1.8 V
+opa2317,OPA317IDCKR,min_op_supply_volt,±0.9 V
+opa2317,OPA317IDCKR,max_op_supply_volt,5.5 V
+opa2317,OPA317IDCKR,max_op_supply_volt,±2.25 V
+opa2317,OPA317IDCKR,min_op_temp,-40
+opa2317,OPA317IDCKR,max_op_temp,125
+opa2317,OPA317IDCKT,part_family,N
+opa2317,OPA317IDCKT,typ_gbp,300.0 kHz
+opa2317,OPA317IDCKT,typ_supply_current,21.0 uA
+opa2317,OPA317IDCKT,min_op_supply_volt,1.8 V
+opa2317,OPA317IDCKT,min_op_supply_volt,±0.9 V
+opa2317,OPA317IDCKT,max_op_supply_volt,5.5 V
+opa2317,OPA317IDCKT,max_op_supply_volt,±2.25 V
+opa2317,OPA317IDCKT,min_op_temp,-40
+opa2317,OPA317IDCKT,max_op_temp,125
+opa2317,OPA317IDR,part_family,N
+opa2317,OPA317IDR,typ_gbp,300.0 kHz
+opa2317,OPA317IDR,typ_supply_current,21.0 uA
+opa2317,OPA317IDR,min_op_supply_volt,1.8 V
+opa2317,OPA317IDR,min_op_supply_volt,±0.9 V
+opa2317,OPA317IDR,max_op_supply_volt,5.5 V
+opa2317,OPA317IDR,max_op_supply_volt,±2.25 V
+opa2317,OPA317IDR,min_op_temp,-40
+opa2317,OPA317IDR,max_op_temp,125
+opa2317,OPA2317,part_family,Y
+opa2317,OPA2317,typ_gbp,300.0 kHz
+opa2317,OPA2317,typ_supply_current,21.0 uA
+opa2317,OPA2317,min_op_supply_volt,1.8 V
+opa2317,OPA2317,min_op_supply_volt,±0.9 V
+opa2317,OPA2317,max_op_supply_volt,5.5 V
+opa2317,OPA2317,max_op_supply_volt,±2.25 V
+opa2317,OPA2317,min_op_temp,-40
+opa2317,OPA2317,max_op_temp,125
+opa2317,OPA2317ID,part_family,N
+opa2317,OPA2317ID,typ_gbp,300.0 kHz
+opa2317,OPA2317ID,typ_supply_current,21.0 uA
+opa2317,OPA2317ID,min_op_supply_volt,1.8 V
+opa2317,OPA2317ID,min_op_supply_volt,±0.9 V
+opa2317,OPA2317ID,max_op_supply_volt,5.5 V
+opa2317,OPA2317ID,max_op_supply_volt,±2.25 V
+opa2317,OPA2317ID,min_op_temp,-40
+opa2317,OPA2317ID,max_op_temp,125
+opa2317,OPA2317IDGKR,part_family,N
+opa2317,OPA2317IDGKR,typ_gbp,300.0 kHz
+opa2317,OPA2317IDGKR,typ_supply_current,21.0 uA
+opa2317,OPA2317IDGKR,min_op_supply_volt,1.8 V
+opa2317,OPA2317IDGKR,min_op_supply_volt,±0.9 V
+opa2317,OPA2317IDGKR,max_op_supply_volt,5.5 V
+opa2317,OPA2317IDGKR,max_op_supply_volt,±2.25 V
+opa2317,OPA2317IDGKR,min_op_temp,-40
+opa2317,OPA2317IDGKR,max_op_temp,125
+opa2317,OPA2317IDGKT,part_family,N
+opa2317,OPA2317IDGKT,typ_gbp,300.0 kHz
+opa2317,OPA2317IDGKT,typ_supply_current,21.0 uA
+opa2317,OPA2317IDGKT,min_op_supply_volt,1.8 V
+opa2317,OPA2317IDGKT,min_op_supply_volt,±0.9 V
+opa2317,OPA2317IDGKT,max_op_supply_volt,5.5 V
+opa2317,OPA2317IDGKT,max_op_supply_volt,±2.25 V
+opa2317,OPA2317IDGKT,min_op_temp,-40
+opa2317,OPA2317IDGKT,max_op_temp,125
+opa2317,OPA2317IDR,part_family,N
+opa2317,OPA2317IDR,typ_gbp,300.0 kHz
+opa2317,OPA2317IDR,typ_supply_current,21.0 uA
+opa2317,OPA2317IDR,min_op_supply_volt,1.8 V
+opa2317,OPA2317IDR,min_op_supply_volt,±0.9 V
+opa2317,OPA2317IDR,max_op_supply_volt,5.5 V
+opa2317,OPA2317IDR,max_op_supply_volt,±2.25 V
+opa2317,OPA2317IDR,min_op_temp,-40
+opa2317,OPA2317IDR,max_op_temp,125
+opa2317,OPA4317,part_family,Y
+opa2317,OPA4317,typ_gbp,300.0 kHz
+opa2317,OPA4317,typ_supply_current,21.0 uA
+opa2317,OPA4317,min_op_supply_volt,1.8 V
+opa2317,OPA4317,min_op_supply_volt,±0.9 V
+opa2317,OPA4317,max_op_supply_volt,5.5 V
+opa2317,OPA4317,max_op_supply_volt,±2.25 V
+opa2317,OPA4317,min_op_temp,-40
+opa2317,OPA4317,max_op_temp,125
+opa2317,OPA4317ID,part_family,N
+opa2317,OPA4317ID,typ_gbp,300.0 kHz
+opa2317,OPA4317ID,typ_supply_current,21.0 uA
+opa2317,OPA4317ID,min_op_supply_volt,1.8 V
+opa2317,OPA4317ID,min_op_supply_volt,±0.9 V
+opa2317,OPA4317ID,max_op_supply_volt,5.5 V
+opa2317,OPA4317ID,max_op_supply_volt,±2.25 V
+opa2317,OPA4317ID,min_op_temp,-40
+opa2317,OPA4317ID,max_op_temp,125
+opa2317,OPA4317IDR,part_family,N
+opa2317,OPA4317IDR,typ_gbp,300.0 kHz
+opa2317,OPA4317IDR,typ_supply_current,21.0 uA
+opa2317,OPA4317IDR,min_op_supply_volt,1.8 V
+opa2317,OPA4317IDR,min_op_supply_volt,±0.9 V
+opa2317,OPA4317IDR,max_op_supply_volt,5.5 V
+opa2317,OPA4317IDR,max_op_supply_volt,±2.25 V
+opa2317,OPA4317IDR,min_op_temp,-40
+opa2317,OPA4317IDR,max_op_temp,125
+opa2317,OPA4317IPW,part_family,N
+opa2317,OPA4317IPW,typ_gbp,300.0 kHz
+opa2317,OPA4317IPW,typ_supply_current,21.0 uA
+opa2317,OPA4317IPW,min_op_supply_volt,1.8 V
+opa2317,OPA4317IPW,min_op_supply_volt,±0.9 V
+opa2317,OPA4317IPW,max_op_supply_volt,5.5 V
+opa2317,OPA4317IPW,max_op_supply_volt,±2.25 V
+opa2317,OPA4317IPW,min_op_temp,-40
+opa2317,OPA4317IPW,max_op_temp,125
+opa2317,OPA4317IPWR,part_family,N
+opa2317,OPA4317IPWR,typ_gbp,300.0 kHz
+opa2317,OPA4317IPWR,typ_supply_current,21.0 uA
+opa2317,OPA4317IPWR,min_op_supply_volt,1.8 V
+opa2317,OPA4317IPWR,min_op_supply_volt,±0.9 V
+opa2317,OPA4317IPWR,max_op_supply_volt,5.5 V
+opa2317,OPA4317IPWR,max_op_supply_volt,±2.25 V
+opa2317,OPA4317IPWR,min_op_temp,-40
+opa2317,OPA4317IPWR,max_op_temp,125
+opa2357,OPA357,part_family,Y
+opa2357,OPA357,typ_gbp,100.0 MHz
+opa2357,OPA357,typ_supply_current,4.9 mA
+opa2357,OPA357,min_op_supply_volt,2.5 V
+opa2357,OPA357,max_op_supply_volt,5.5 V
+opa2357,OPA357,min_op_temp,-40
+opa2357,OPA357,max_op_temp,125
+opa2357,OPA357AIDBVR,part_family,N
+opa2357,OPA357AIDBVR,typ_gbp,100.0 MHz
+opa2357,OPA357AIDBVR,typ_supply_current,4.9 mA
+opa2357,OPA357AIDBVR,min_op_supply_volt,2.5 V
+opa2357,OPA357AIDBVR,max_op_supply_volt,5.5 V
+opa2357,OPA357AIDBVR,min_op_temp,-40
+opa2357,OPA357AIDBVR,max_op_temp,125
+opa2357,OPA357AIDBVRG4,part_family,N
+opa2357,OPA357AIDBVRG4,typ_gbp,100.0 MHz
+opa2357,OPA357AIDBVRG4,typ_supply_current,4.9 mA
+opa2357,OPA357AIDBVRG4,min_op_supply_volt,2.5 V
+opa2357,OPA357AIDBVRG4,max_op_supply_volt,5.5 V
+opa2357,OPA357AIDBVRG4,min_op_temp,-40
+opa2357,OPA357AIDBVRG4,max_op_temp,125
+opa2357,OPA357AIDBVT,part_family,N
+opa2357,OPA357AIDBVT,typ_gbp,100.0 MHz
+opa2357,OPA357AIDBVT,typ_supply_current,4.9 mA
+opa2357,OPA357AIDBVT,min_op_supply_volt,2.5 V
+opa2357,OPA357AIDBVT,max_op_supply_volt,5.5 V
+opa2357,OPA357AIDBVT,min_op_temp,-40
+opa2357,OPA357AIDBVT,max_op_temp,125
+opa2357,OPA357AIDBVTG4,part_family,N
+opa2357,OPA357AIDBVTG4,typ_gbp,100.0 MHz
+opa2357,OPA357AIDBVTG4,typ_supply_current,4.9 mA
+opa2357,OPA357AIDBVTG4,min_op_supply_volt,2.5 V
+opa2357,OPA357AIDBVTG4,max_op_supply_volt,5.5 V
+opa2357,OPA357AIDBVTG4,min_op_temp,-40
+opa2357,OPA357AIDBVTG4,max_op_temp,125
+opa2357,OPA357AIDDA,part_family,N
+opa2357,OPA357AIDDA,typ_gbp,100.0 MHz
+opa2357,OPA357AIDDA,typ_supply_current,4.9 mA
+opa2357,OPA357AIDDA,min_op_supply_volt,2.5 V
+opa2357,OPA357AIDDA,max_op_supply_volt,5.5 V
+opa2357,OPA357AIDDA,min_op_temp,-40
+opa2357,OPA357AIDDA,max_op_temp,125
+opa2357,OPA357AIDDAR,part_family,N
+opa2357,OPA357AIDDAR,typ_gbp,100.0 MHz
+opa2357,OPA357AIDDAR,typ_supply_current,4.9 mA
+opa2357,OPA357AIDDAR,min_op_supply_volt,2.5 V
+opa2357,OPA357AIDDAR,max_op_supply_volt,5.5 V
+opa2357,OPA357AIDDAR,min_op_temp,-40
+opa2357,OPA357AIDDAR,max_op_temp,125
+opa2357,OPA2357,part_family,Y
+opa2357,OPA2357,typ_gbp,100.0 MHz
+opa2357,OPA2357,typ_supply_current,4.9 mA
+opa2357,OPA2357,min_op_supply_volt,2.5 V
+opa2357,OPA2357,max_op_supply_volt,5.5 V
+opa2357,OPA2357,min_op_temp,-40
+opa2357,OPA2357,max_op_temp,125
+opa2357,OPA2357AIDGSR,part_family,N
+opa2357,OPA2357AIDGSR,typ_gbp,100.0 MHz
+opa2357,OPA2357AIDGSR,typ_supply_current,4.9 mA
+opa2357,OPA2357AIDGSR,min_op_supply_volt,2.5 V
+opa2357,OPA2357AIDGSR,max_op_supply_volt,5.5 V
+opa2357,OPA2357AIDGSR,min_op_temp,-40
+opa2357,OPA2357AIDGSR,max_op_temp,125
+opa2357,OPA2357AIDGSRG4,part_family,N
+opa2357,OPA2357AIDGSRG4,typ_gbp,100.0 MHz
+opa2357,OPA2357AIDGSRG4,typ_supply_current,4.9 mA
+opa2357,OPA2357AIDGSRG4,min_op_supply_volt,2.5 V
+opa2357,OPA2357AIDGSRG4,max_op_supply_volt,5.5 V
+opa2357,OPA2357AIDGSRG4,min_op_temp,-40
+opa2357,OPA2357AIDGSRG4,max_op_temp,125
+opa2357,OPA2357AIDGST,part_family,N
+opa2357,OPA2357AIDGST,typ_gbp,100.0 MHz
+opa2357,OPA2357AIDGST,typ_supply_current,4.9 mA
+opa2357,OPA2357AIDGST,min_op_supply_volt,2.5 V
+opa2357,OPA2357AIDGST,max_op_supply_volt,5.5 V
+opa2357,OPA2357AIDGST,min_op_temp,-40
+opa2357,OPA2357AIDGST,max_op_temp,125
+opa2357,OPA2357AIDGSTG4,part_family,N
+opa2357,OPA2357AIDGSTG4,typ_gbp,100.0 MHz
+opa2357,OPA2357AIDGSTG4,typ_supply_current,4.9 mA
+opa2357,OPA2357AIDGSTG4,min_op_supply_volt,2.5 V
+opa2357,OPA2357AIDGSTG4,max_op_supply_volt,5.5 V
+opa2357,OPA2357AIDGSTG4,min_op_temp,-40
+opa2357,OPA2357AIDGSTG4,max_op_temp,125
+opa363,OPA363,part_family,Y
+opa363,OPA363,typ_gbp,7.0 MHz
+opa363,OPA363,typ_supply_current,650.0 uA
+opa363,OPA363,typ_supply_current,850.0 uA
+opa363,OPA363,typ_supply_current,1.1 mA
+opa363,OPA363,min_op_supply_volt,1.8 V
+opa363,OPA363,max_op_supply_volt,5.5 V
+opa363,OPA363,min_op_temp,-40
+opa363,OPA363,max_op_temp,125
+opa363,OPA363AID,part_family,N
+opa363,OPA363AID,typ_gbp,7.0 MHz
+opa363,OPA363AID,typ_supply_current,650.0 uA
+opa363,OPA363AID,typ_supply_current,850.0 uA
+opa363,OPA363AID,typ_supply_current,1.1 mA
+opa363,OPA363AID,min_op_supply_volt,1.8 V
+opa363,OPA363AID,max_op_supply_volt,5.5 V
+opa363,OPA363AID,min_op_temp,-40
+opa363,OPA363AID,max_op_temp,125
+opa363,OPA363AIDBVR,part_family,N
+opa363,OPA363AIDBVR,typ_gbp,7.0 MHz
+opa363,OPA363AIDBVR,typ_supply_current,650.0 uA
+opa363,OPA363AIDBVR,typ_supply_current,850.0 uA
+opa363,OPA363AIDBVR,typ_supply_current,1.1 mA
+opa363,OPA363AIDBVR,min_op_supply_volt,1.8 V
+opa363,OPA363AIDBVR,max_op_supply_volt,5.5 V
+opa363,OPA363AIDBVR,min_op_temp,-40
+opa363,OPA363AIDBVR,max_op_temp,125
+opa363,OPA363AIDBVRG4,part_family,N
+opa363,OPA363AIDBVRG4,typ_gbp,7.0 MHz
+opa363,OPA363AIDBVRG4,typ_supply_current,650.0 uA
+opa363,OPA363AIDBVRG4,typ_supply_current,850.0 uA
+opa363,OPA363AIDBVRG4,typ_supply_current,1.1 mA
+opa363,OPA363AIDBVRG4,min_op_supply_volt,1.8 V
+opa363,OPA363AIDBVRG4,max_op_supply_volt,5.5 V
+opa363,OPA363AIDBVRG4,min_op_temp,-40
+opa363,OPA363AIDBVRG4,max_op_temp,125
+opa363,OPA363AIDBVT,part_family,N
+opa363,OPA363AIDBVT,typ_gbp,7.0 MHz
+opa363,OPA363AIDBVT,typ_supply_current,650.0 uA
+opa363,OPA363AIDBVT,typ_supply_current,850.0 uA
+opa363,OPA363AIDBVT,typ_supply_current,1.1 mA
+opa363,OPA363AIDBVT,min_op_supply_volt,1.8 V
+opa363,OPA363AIDBVT,max_op_supply_volt,5.5 V
+opa363,OPA363AIDBVT,min_op_temp,-40
+opa363,OPA363AIDBVT,max_op_temp,125
+opa363,OPA363AIDBVTG4,part_family,N
+opa363,OPA363AIDBVTG4,typ_gbp,7.0 MHz
+opa363,OPA363AIDBVTG4,typ_supply_current,650.0 uA
+opa363,OPA363AIDBVTG4,typ_supply_current,850.0 uA
+opa363,OPA363AIDBVTG4,typ_supply_current,1.1 mA
+opa363,OPA363AIDBVTG4,min_op_supply_volt,1.8 V
+opa363,OPA363AIDBVTG4,max_op_supply_volt,5.5 V
+opa363,OPA363AIDBVTG4,min_op_temp,-40
+opa363,OPA363AIDBVTG4,max_op_temp,125
+opa363,OPA363ID,part_family,N
+opa363,OPA363ID,typ_gbp,7.0 MHz
+opa363,OPA363ID,typ_supply_current,650.0 uA
+opa363,OPA363ID,typ_supply_current,850.0 uA
+opa363,OPA363ID,typ_supply_current,1.1 mA
+opa363,OPA363ID,min_op_supply_volt,1.8 V
+opa363,OPA363ID,max_op_supply_volt,5.5 V
+opa363,OPA363ID,min_op_temp,-40
+opa363,OPA363ID,max_op_temp,125
+opa363,OPA363IDBVR,part_family,N
+opa363,OPA363IDBVR,typ_gbp,7.0 MHz
+opa363,OPA363IDBVR,typ_supply_current,650.0 uA
+opa363,OPA363IDBVR,typ_supply_current,850.0 uA
+opa363,OPA363IDBVR,typ_supply_current,1.1 mA
+opa363,OPA363IDBVR,min_op_supply_volt,1.8 V
+opa363,OPA363IDBVR,max_op_supply_volt,5.5 V
+opa363,OPA363IDBVR,min_op_temp,-40
+opa363,OPA363IDBVR,max_op_temp,125
+opa363,OPA363IDBVRG4,part_family,N
+opa363,OPA363IDBVRG4,typ_gbp,7.0 MHz
+opa363,OPA363IDBVRG4,typ_supply_current,650.0 uA
+opa363,OPA363IDBVRG4,typ_supply_current,850.0 uA
+opa363,OPA363IDBVRG4,typ_supply_current,1.1 mA
+opa363,OPA363IDBVRG4,min_op_supply_volt,1.8 V
+opa363,OPA363IDBVRG4,max_op_supply_volt,5.5 V
+opa363,OPA363IDBVRG4,min_op_temp,-40
+opa363,OPA363IDBVRG4,max_op_temp,125
+opa363,OPA363IDBVT,part_family,N
+opa363,OPA363IDBVT,typ_gbp,7.0 MHz
+opa363,OPA363IDBVT,typ_supply_current,650.0 uA
+opa363,OPA363IDBVT,typ_supply_current,850.0 uA
+opa363,OPA363IDBVT,typ_supply_current,1.1 mA
+opa363,OPA363IDBVT,min_op_supply_volt,1.8 V
+opa363,OPA363IDBVT,max_op_supply_volt,5.5 V
+opa363,OPA363IDBVT,min_op_temp,-40
+opa363,OPA363IDBVT,max_op_temp,125
+opa363,OPA363IDBVTG4,part_family,N
+opa363,OPA363IDBVTG4,typ_gbp,7.0 MHz
+opa363,OPA363IDBVTG4,typ_supply_current,650.0 uA
+opa363,OPA363IDBVTG4,typ_supply_current,850.0 uA
+opa363,OPA363IDBVTG4,typ_supply_current,1.1 mA
+opa363,OPA363IDBVTG4,min_op_supply_volt,1.8 V
+opa363,OPA363IDBVTG4,max_op_supply_volt,5.5 V
+opa363,OPA363IDBVTG4,min_op_temp,-40
+opa363,OPA363IDBVTG4,max_op_temp,125
+opa363,OPA363IDG4,part_family,N
+opa363,OPA363IDG4,typ_gbp,7.0 MHz
+opa363,OPA363IDG4,typ_supply_current,650.0 uA
+opa363,OPA363IDG4,typ_supply_current,850.0 uA
+opa363,OPA363IDG4,typ_supply_current,1.1 mA
+opa363,OPA363IDG4,min_op_supply_volt,1.8 V
+opa363,OPA363IDG4,max_op_supply_volt,5.5 V
+opa363,OPA363IDG4,min_op_temp,-40
+opa363,OPA363IDG4,max_op_temp,125
+opa363,OPA2363,part_family,Y
+opa363,OPA2363,typ_gbp,7.0 MHz
+opa363,OPA2363,typ_supply_current,650.0 uA
+opa363,OPA2363,typ_supply_current,850.0 uA
+opa363,OPA2363,typ_supply_current,1.1 mA
+opa363,OPA2363,min_op_supply_volt,1.8 V
+opa363,OPA2363,max_op_supply_volt,5.5 V
+opa363,OPA2363,min_op_temp,-40
+opa363,OPA2363,max_op_temp,125
+opa363,OPA2363AIDGSR,part_family,N
+opa363,OPA2363AIDGSR,typ_gbp,7.0 MHz
+opa363,OPA2363AIDGSR,typ_supply_current,650.0 uA
+opa363,OPA2363AIDGSR,typ_supply_current,850.0 uA
+opa363,OPA2363AIDGSR,typ_supply_current,1.1 mA
+opa363,OPA2363AIDGSR,min_op_supply_volt,1.8 V
+opa363,OPA2363AIDGSR,max_op_supply_volt,5.5 V
+opa363,OPA2363AIDGSR,min_op_temp,-40
+opa363,OPA2363AIDGSR,max_op_temp,125
+opa363,OPA2363AIDGST,part_family,N
+opa363,OPA2363AIDGST,typ_gbp,7.0 MHz
+opa363,OPA2363AIDGST,typ_supply_current,650.0 uA
+opa363,OPA2363AIDGST,typ_supply_current,850.0 uA
+opa363,OPA2363AIDGST,typ_supply_current,1.1 mA
+opa363,OPA2363AIDGST,min_op_supply_volt,1.8 V
+opa363,OPA2363AIDGST,max_op_supply_volt,5.5 V
+opa363,OPA2363AIDGST,min_op_temp,-40
+opa363,OPA2363AIDGST,max_op_temp,125
+opa363,OPA2363AIDGSTG4,part_family,N
+opa363,OPA2363AIDGSTG4,typ_gbp,7.0 MHz
+opa363,OPA2363AIDGSTG4,typ_supply_current,650.0 uA
+opa363,OPA2363AIDGSTG4,typ_supply_current,850.0 uA
+opa363,OPA2363AIDGSTG4,typ_supply_current,1.1 mA
+opa363,OPA2363AIDGSTG4,min_op_supply_volt,1.8 V
+opa363,OPA2363AIDGSTG4,max_op_supply_volt,5.5 V
+opa363,OPA2363AIDGSTG4,min_op_temp,-40
+opa363,OPA2363AIDGSTG4,max_op_temp,125
+opa363,OPA2363AIRSVR,part_family,N
+opa363,OPA2363AIRSVR,typ_gbp,7.0 MHz
+opa363,OPA2363AIRSVR,typ_supply_current,650.0 uA
+opa363,OPA2363AIRSVR,typ_supply_current,850.0 uA
+opa363,OPA2363AIRSVR,typ_supply_current,1.1 mA
+opa363,OPA2363AIRSVR,min_op_supply_volt,1.8 V
+opa363,OPA2363AIRSVR,max_op_supply_volt,5.5 V
+opa363,OPA2363AIRSVR,min_op_temp,-40
+opa363,OPA2363AIRSVR,max_op_temp,125
+opa363,OPA2363IDGSR,part_family,N
+opa363,OPA2363IDGSR,typ_gbp,7.0 MHz
+opa363,OPA2363IDGSR,typ_supply_current,650.0 uA
+opa363,OPA2363IDGSR,typ_supply_current,850.0 uA
+opa363,OPA2363IDGSR,typ_supply_current,1.1 mA
+opa363,OPA2363IDGSR,min_op_supply_volt,1.8 V
+opa363,OPA2363IDGSR,max_op_supply_volt,5.5 V
+opa363,OPA2363IDGSR,min_op_temp,-40
+opa363,OPA2363IDGSR,max_op_temp,125
+opa363,OPA2363IDGST,part_family,N
+opa363,OPA2363IDGST,typ_gbp,7.0 MHz
+opa363,OPA2363IDGST,typ_supply_current,650.0 uA
+opa363,OPA2363IDGST,typ_supply_current,850.0 uA
+opa363,OPA2363IDGST,typ_supply_current,1.1 mA
+opa363,OPA2363IDGST,min_op_supply_volt,1.8 V
+opa363,OPA2363IDGST,max_op_supply_volt,5.5 V
+opa363,OPA2363IDGST,min_op_temp,-40
+opa363,OPA2363IDGST,max_op_temp,125
+opa363,OPA2363IDGSTG4,part_family,N
+opa363,OPA2363IDGSTG4,typ_gbp,7.0 MHz
+opa363,OPA2363IDGSTG4,typ_supply_current,650.0 uA
+opa363,OPA2363IDGSTG4,typ_supply_current,850.0 uA
+opa363,OPA2363IDGSTG4,typ_supply_current,1.1 mA
+opa363,OPA2363IDGSTG4,min_op_supply_volt,1.8 V
+opa363,OPA2363IDGSTG4,max_op_supply_volt,5.5 V
+opa363,OPA2363IDGSTG4,min_op_temp,-40
+opa363,OPA2363IDGSTG4,max_op_temp,125
+opa363,OPA364,part_family,Y
+opa363,OPA364,typ_gbp,7.0 MHz
+opa363,OPA364,typ_supply_current,650.0 uA
+opa363,OPA364,typ_supply_current,850.0 uA
+opa363,OPA364,typ_supply_current,1.1 mA
+opa363,OPA364,min_op_supply_volt,1.8 V
+opa363,OPA364,max_op_supply_volt,5.5 V
+opa363,OPA364,min_op_temp,-40
+opa363,OPA364,max_op_temp,125
+opa363,OPA364AID,part_family,N
+opa363,OPA364AID,typ_gbp,7.0 MHz
+opa363,OPA364AID,typ_supply_current,650.0 uA
+opa363,OPA364AID,typ_supply_current,850.0 uA
+opa363,OPA364AID,typ_supply_current,1.1 mA
+opa363,OPA364AID,min_op_supply_volt,1.8 V
+opa363,OPA364AID,max_op_supply_volt,5.5 V
+opa363,OPA364AID,min_op_temp,-40
+opa363,OPA364AID,max_op_temp,125
+opa363,OPA364AIDBVR,part_family,N
+opa363,OPA364AIDBVR,typ_gbp,7.0 MHz
+opa363,OPA364AIDBVR,typ_supply_current,650.0 uA
+opa363,OPA364AIDBVR,typ_supply_current,850.0 uA
+opa363,OPA364AIDBVR,typ_supply_current,1.1 mA
+opa363,OPA364AIDBVR,min_op_supply_volt,1.8 V
+opa363,OPA364AIDBVR,max_op_supply_volt,5.5 V
+opa363,OPA364AIDBVR,min_op_temp,-40
+opa363,OPA364AIDBVR,max_op_temp,125
+opa363,OPA364AIDBVRG4,part_family,N
+opa363,OPA364AIDBVRG4,typ_gbp,7.0 MHz
+opa363,OPA364AIDBVRG4,typ_supply_current,650.0 uA
+opa363,OPA364AIDBVRG4,typ_supply_current,850.0 uA
+opa363,OPA364AIDBVRG4,typ_supply_current,1.1 mA
+opa363,OPA364AIDBVRG4,min_op_supply_volt,1.8 V
+opa363,OPA364AIDBVRG4,max_op_supply_volt,5.5 V
+opa363,OPA364AIDBVRG4,min_op_temp,-40
+opa363,OPA364AIDBVRG4,max_op_temp,125
+opa363,OPA364AIDBVT,part_family,N
+opa363,OPA364AIDBVT,typ_gbp,7.0 MHz
+opa363,OPA364AIDBVT,typ_supply_current,650.0 uA
+opa363,OPA364AIDBVT,typ_supply_current,850.0 uA
+opa363,OPA364AIDBVT,typ_supply_current,1.1 mA
+opa363,OPA364AIDBVT,min_op_supply_volt,1.8 V
+opa363,OPA364AIDBVT,max_op_supply_volt,5.5 V
+opa363,OPA364AIDBVT,min_op_temp,-40
+opa363,OPA364AIDBVT,max_op_temp,125
+opa363,OPA364AIDBVTG4,part_family,N
+opa363,OPA364AIDBVTG4,typ_gbp,7.0 MHz
+opa363,OPA364AIDBVTG4,typ_supply_current,650.0 uA
+opa363,OPA364AIDBVTG4,typ_supply_current,850.0 uA
+opa363,OPA364AIDBVTG4,typ_supply_current,1.1 mA
+opa363,OPA364AIDBVTG4,min_op_supply_volt,1.8 V
+opa363,OPA364AIDBVTG4,max_op_supply_volt,5.5 V
+opa363,OPA364AIDBVTG4,min_op_temp,-40
+opa363,OPA364AIDBVTG4,max_op_temp,125
+opa363,OPA364AIDR,part_family,N
+opa363,OPA364AIDR,typ_gbp,7.0 MHz
+opa363,OPA364AIDR,typ_supply_current,650.0 uA
+opa363,OPA364AIDR,typ_supply_current,850.0 uA
+opa363,OPA364AIDR,typ_supply_current,1.1 mA
+opa363,OPA364AIDR,min_op_supply_volt,1.8 V
+opa363,OPA364AIDR,max_op_supply_volt,5.5 V
+opa363,OPA364AIDR,min_op_temp,-40
+opa363,OPA364AIDR,max_op_temp,125
+opa363,OPA364ID,part_family,N
+opa363,OPA364ID,typ_gbp,7.0 MHz
+opa363,OPA364ID,typ_supply_current,650.0 uA
+opa363,OPA364ID,typ_supply_current,850.0 uA
+opa363,OPA364ID,typ_supply_current,1.1 mA
+opa363,OPA364ID,min_op_supply_volt,1.8 V
+opa363,OPA364ID,max_op_supply_volt,5.5 V
+opa363,OPA364ID,min_op_temp,-40
+opa363,OPA364ID,max_op_temp,125
+opa363,OPA364IDBVR,part_family,N
+opa363,OPA364IDBVR,typ_gbp,7.0 MHz
+opa363,OPA364IDBVR,typ_supply_current,650.0 uA
+opa363,OPA364IDBVR,typ_supply_current,850.0 uA
+opa363,OPA364IDBVR,typ_supply_current,1.1 mA
+opa363,OPA364IDBVR,min_op_supply_volt,1.8 V
+opa363,OPA364IDBVR,max_op_supply_volt,5.5 V
+opa363,OPA364IDBVR,min_op_temp,-40
+opa363,OPA364IDBVR,max_op_temp,125
+opa363,OPA364IDBVRG4,part_family,N
+opa363,OPA364IDBVRG4,typ_gbp,7.0 MHz
+opa363,OPA364IDBVRG4,typ_supply_current,650.0 uA
+opa363,OPA364IDBVRG4,typ_supply_current,850.0 uA
+opa363,OPA364IDBVRG4,typ_supply_current,1.1 mA
+opa363,OPA364IDBVRG4,min_op_supply_volt,1.8 V
+opa363,OPA364IDBVRG4,max_op_supply_volt,5.5 V
+opa363,OPA364IDBVRG4,min_op_temp,-40
+opa363,OPA364IDBVRG4,max_op_temp,125
+opa363,OPA364IDBVT,part_family,N
+opa363,OPA364IDBVT,typ_gbp,7.0 MHz
+opa363,OPA364IDBVT,typ_supply_current,650.0 uA
+opa363,OPA364IDBVT,typ_supply_current,850.0 uA
+opa363,OPA364IDBVT,typ_supply_current,1.1 mA
+opa363,OPA364IDBVT,min_op_supply_volt,1.8 V
+opa363,OPA364IDBVT,max_op_supply_volt,5.5 V
+opa363,OPA364IDBVT,min_op_temp,-40
+opa363,OPA364IDBVT,max_op_temp,125
+opa363,OPA364IDBVTG4,part_family,N
+opa363,OPA364IDBVTG4,typ_gbp,7.0 MHz
+opa363,OPA364IDBVTG4,typ_supply_current,650.0 uA
+opa363,OPA364IDBVTG4,typ_supply_current,850.0 uA
+opa363,OPA364IDBVTG4,typ_supply_current,1.1 mA
+opa363,OPA364IDBVTG4,min_op_supply_volt,1.8 V
+opa363,OPA364IDBVTG4,max_op_supply_volt,5.5 V
+opa363,OPA364IDBVTG4,min_op_temp,-40
+opa363,OPA364IDBVTG4,max_op_temp,125
+opa363,OPA364IDG4,part_family,N
+opa363,OPA364IDG4,typ_gbp,7.0 MHz
+opa363,OPA364IDG4,typ_supply_current,650.0 uA
+opa363,OPA364IDG4,typ_supply_current,850.0 uA
+opa363,OPA364IDG4,typ_supply_current,1.1 mA
+opa363,OPA364IDG4,min_op_supply_volt,1.8 V
+opa363,OPA364IDG4,max_op_supply_volt,5.5 V
+opa363,OPA364IDG4,min_op_temp,-40
+opa363,OPA364IDG4,max_op_temp,125
+opa363,OPA364IDR,part_family,N
+opa363,OPA364IDR,typ_gbp,7.0 MHz
+opa363,OPA364IDR,typ_supply_current,650.0 uA
+opa363,OPA364IDR,typ_supply_current,850.0 uA
+opa363,OPA364IDR,typ_supply_current,1.1 mA
+opa363,OPA364IDR,min_op_supply_volt,1.8 V
+opa363,OPA364IDR,max_op_supply_volt,5.5 V
+opa363,OPA364IDR,min_op_temp,-40
+opa363,OPA364IDR,max_op_temp,125
+opa363,OPA364IDRG4,part_family,N
+opa363,OPA364IDRG4,typ_gbp,7.0 MHz
+opa363,OPA364IDRG4,typ_supply_current,650.0 uA
+opa363,OPA364IDRG4,typ_supply_current,850.0 uA
+opa363,OPA364IDRG4,typ_supply_current,1.1 mA
+opa363,OPA364IDRG4,min_op_supply_volt,1.8 V
+opa363,OPA364IDRG4,max_op_supply_volt,5.5 V
+opa363,OPA364IDRG4,min_op_temp,-40
+opa363,OPA364IDRG4,max_op_temp,125
+opa363,OPA2364,part_family,Y
+opa363,OPA2364,typ_gbp,7.0 MHz
+opa363,OPA2364,typ_supply_current,650.0 uA
+opa363,OPA2364,typ_supply_current,850.0 uA
+opa363,OPA2364,typ_supply_current,1.1 mA
+opa363,OPA2364,min_op_supply_volt,1.8 V
+opa363,OPA2364,max_op_supply_volt,5.5 V
+opa363,OPA2364,min_op_temp,-40
+opa363,OPA2364,max_op_temp,125
+opa363,OPA2364AID,part_family,N
+opa363,OPA2364AID,typ_gbp,7.0 MHz
+opa363,OPA2364AID,typ_supply_current,650.0 uA
+opa363,OPA2364AID,typ_supply_current,850.0 uA
+opa363,OPA2364AID,typ_supply_current,1.1 mA
+opa363,OPA2364AID,min_op_supply_volt,1.8 V
+opa363,OPA2364AID,max_op_supply_volt,5.5 V
+opa363,OPA2364AID,min_op_temp,-40
+opa363,OPA2364AID,max_op_temp,125
+opa363,OPA2364AIDG4,part_family,N
+opa363,OPA2364AIDG4,typ_gbp,7.0 MHz
+opa363,OPA2364AIDG4,typ_supply_current,650.0 uA
+opa363,OPA2364AIDG4,typ_supply_current,850.0 uA
+opa363,OPA2364AIDG4,typ_supply_current,1.1 mA
+opa363,OPA2364AIDG4,min_op_supply_volt,1.8 V
+opa363,OPA2364AIDG4,max_op_supply_volt,5.5 V
+opa363,OPA2364AIDG4,min_op_temp,-40
+opa363,OPA2364AIDG4,max_op_temp,125
+opa363,OPA2364AIDGKR,part_family,N
+opa363,OPA2364AIDGKR,typ_gbp,7.0 MHz
+opa363,OPA2364AIDGKR,typ_supply_current,650.0 uA
+opa363,OPA2364AIDGKR,typ_supply_current,850.0 uA
+opa363,OPA2364AIDGKR,typ_supply_current,1.1 mA
+opa363,OPA2364AIDGKR,min_op_supply_volt,1.8 V
+opa363,OPA2364AIDGKR,max_op_supply_volt,5.5 V
+opa363,OPA2364AIDGKR,min_op_temp,-40
+opa363,OPA2364AIDGKR,max_op_temp,125
+opa363,OPA2364AIDGKRG4,part_family,N
+opa363,OPA2364AIDGKRG4,typ_gbp,7.0 MHz
+opa363,OPA2364AIDGKRG4,typ_supply_current,650.0 uA
+opa363,OPA2364AIDGKRG4,typ_supply_current,850.0 uA
+opa363,OPA2364AIDGKRG4,typ_supply_current,1.1 mA
+opa363,OPA2364AIDGKRG4,min_op_supply_volt,1.8 V
+opa363,OPA2364AIDGKRG4,max_op_supply_volt,5.5 V
+opa363,OPA2364AIDGKRG4,min_op_temp,-40
+opa363,OPA2364AIDGKRG4,max_op_temp,125
+opa363,OPA2364AIDGKT,part_family,N
+opa363,OPA2364AIDGKT,typ_gbp,7.0 MHz
+opa363,OPA2364AIDGKT,typ_supply_current,650.0 uA
+opa363,OPA2364AIDGKT,typ_supply_current,850.0 uA
+opa363,OPA2364AIDGKT,typ_supply_current,1.1 mA
+opa363,OPA2364AIDGKT,min_op_supply_volt,1.8 V
+opa363,OPA2364AIDGKT,max_op_supply_volt,5.5 V
+opa363,OPA2364AIDGKT,min_op_temp,-40
+opa363,OPA2364AIDGKT,max_op_temp,125
+opa363,OPA2364AIDGKTG4,part_family,N
+opa363,OPA2364AIDGKTG4,typ_gbp,7.0 MHz
+opa363,OPA2364AIDGKTG4,typ_supply_current,650.0 uA
+opa363,OPA2364AIDGKTG4,typ_supply_current,850.0 uA
+opa363,OPA2364AIDGKTG4,typ_supply_current,1.1 mA
+opa363,OPA2364AIDGKTG4,min_op_supply_volt,1.8 V
+opa363,OPA2364AIDGKTG4,max_op_supply_volt,5.5 V
+opa363,OPA2364AIDGKTG4,min_op_temp,-40
+opa363,OPA2364AIDGKTG4,max_op_temp,125
+opa363,OPA2364AIDR,part_family,N
+opa363,OPA2364AIDR,typ_gbp,7.0 MHz
+opa363,OPA2364AIDR,typ_supply_current,650.0 uA
+opa363,OPA2364AIDR,typ_supply_current,850.0 uA
+opa363,OPA2364AIDR,typ_supply_current,1.1 mA
+opa363,OPA2364AIDR,min_op_supply_volt,1.8 V
+opa363,OPA2364AIDR,max_op_supply_volt,5.5 V
+opa363,OPA2364AIDR,min_op_temp,-40
+opa363,OPA2364AIDR,max_op_temp,125
+opa363,OPA2364AIDRG4,part_family,N
+opa363,OPA2364AIDRG4,typ_gbp,7.0 MHz
+opa363,OPA2364AIDRG4,typ_supply_current,650.0 uA
+opa363,OPA2364AIDRG4,typ_supply_current,850.0 uA
+opa363,OPA2364AIDRG4,typ_supply_current,1.1 mA
+opa363,OPA2364AIDRG4,min_op_supply_volt,1.8 V
+opa363,OPA2364AIDRG4,max_op_supply_volt,5.5 V
+opa363,OPA2364AIDRG4,min_op_temp,-40
+opa363,OPA2364AIDRG4,max_op_temp,125
+opa363,OPA2364ID,part_family,N
+opa363,OPA2364ID,typ_gbp,7.0 MHz
+opa363,OPA2364ID,typ_supply_current,650.0 uA
+opa363,OPA2364ID,typ_supply_current,850.0 uA
+opa363,OPA2364ID,typ_supply_current,1.1 mA
+opa363,OPA2364ID,min_op_supply_volt,1.8 V
+opa363,OPA2364ID,max_op_supply_volt,5.5 V
+opa363,OPA2364ID,min_op_temp,-40
+opa363,OPA2364ID,max_op_temp,125
+opa363,OPA2364IDG4,part_family,N
+opa363,OPA2364IDG4,typ_gbp,7.0 MHz
+opa363,OPA2364IDG4,typ_supply_current,650.0 uA
+opa363,OPA2364IDG4,typ_supply_current,850.0 uA
+opa363,OPA2364IDG4,typ_supply_current,1.1 mA
+opa363,OPA2364IDG4,min_op_supply_volt,1.8 V
+opa363,OPA2364IDG4,max_op_supply_volt,5.5 V
+opa363,OPA2364IDG4,min_op_temp,-40
+opa363,OPA2364IDG4,max_op_temp,125
+opa363,OPA2364IDGKR,part_family,N
+opa363,OPA2364IDGKR,typ_gbp,7.0 MHz
+opa363,OPA2364IDGKR,typ_supply_current,650.0 uA
+opa363,OPA2364IDGKR,typ_supply_current,850.0 uA
+opa363,OPA2364IDGKR,typ_supply_current,1.1 mA
+opa363,OPA2364IDGKR,min_op_supply_volt,1.8 V
+opa363,OPA2364IDGKR,max_op_supply_volt,5.5 V
+opa363,OPA2364IDGKR,min_op_temp,-40
+opa363,OPA2364IDGKR,max_op_temp,125
+opa363,OPA2364IDGKRG4,part_family,N
+opa363,OPA2364IDGKRG4,typ_gbp,7.0 MHz
+opa363,OPA2364IDGKRG4,typ_supply_current,650.0 uA
+opa363,OPA2364IDGKRG4,typ_supply_current,850.0 uA
+opa363,OPA2364IDGKRG4,typ_supply_current,1.1 mA
+opa363,OPA2364IDGKRG4,min_op_supply_volt,1.8 V
+opa363,OPA2364IDGKRG4,max_op_supply_volt,5.5 V
+opa363,OPA2364IDGKRG4,min_op_temp,-40
+opa363,OPA2364IDGKRG4,max_op_temp,125
+opa363,OPA2364IDGKT,part_family,N
+opa363,OPA2364IDGKT,typ_gbp,7.0 MHz
+opa363,OPA2364IDGKT,typ_supply_current,650.0 uA
+opa363,OPA2364IDGKT,typ_supply_current,850.0 uA
+opa363,OPA2364IDGKT,typ_supply_current,1.1 mA
+opa363,OPA2364IDGKT,min_op_supply_volt,1.8 V
+opa363,OPA2364IDGKT,max_op_supply_volt,5.5 V
+opa363,OPA2364IDGKT,min_op_temp,-40
+opa363,OPA2364IDGKT,max_op_temp,125
+opa363,OPA2364IDGKTG4,part_family,N
+opa363,OPA2364IDGKTG4,typ_gbp,7.0 MHz
+opa363,OPA2364IDGKTG4,typ_supply_current,650.0 uA
+opa363,OPA2364IDGKTG4,typ_supply_current,850.0 uA
+opa363,OPA2364IDGKTG4,typ_supply_current,1.1 mA
+opa363,OPA2364IDGKTG4,min_op_supply_volt,1.8 V
+opa363,OPA2364IDGKTG4,max_op_supply_volt,5.5 V
+opa363,OPA2364IDGKTG4,min_op_temp,-40
+opa363,OPA2364IDGKTG4,max_op_temp,125
+opa363,OPA2364IDR,part_family,N
+opa363,OPA2364IDR,typ_gbp,7.0 MHz
+opa363,OPA2364IDR,typ_supply_current,650.0 uA
+opa363,OPA2364IDR,typ_supply_current,850.0 uA
+opa363,OPA2364IDR,typ_supply_current,1.1 mA
+opa363,OPA2364IDR,min_op_supply_volt,1.8 V
+opa363,OPA2364IDR,max_op_supply_volt,5.5 V
+opa363,OPA2364IDR,min_op_temp,-40
+opa363,OPA2364IDR,max_op_temp,125
+opa363,OPA2364IDRG4,part_family,N
+opa363,OPA2364IDRG4,typ_gbp,7.0 MHz
+opa363,OPA2364IDRG4,typ_supply_current,650.0 uA
+opa363,OPA2364IDRG4,typ_supply_current,850.0 uA
+opa363,OPA2364IDRG4,typ_supply_current,1.1 mA
+opa363,OPA2364IDRG4,min_op_supply_volt,1.8 V
+opa363,OPA2364IDRG4,max_op_supply_volt,5.5 V
+opa363,OPA2364IDRG4,min_op_temp,-40
+opa363,OPA2364IDRG4,max_op_temp,125
+opa363,OPA4364,part_family,Y
+opa363,OPA4364,typ_gbp,7.0 MHz
+opa363,OPA4364,typ_supply_current,650.0 uA
+opa363,OPA4364,typ_supply_current,850.0 uA
+opa363,OPA4364,typ_supply_current,1.1 mA
+opa363,OPA4364,min_op_supply_volt,1.8 V
+opa363,OPA4364,max_op_supply_volt,5.5 V
+opa363,OPA4364,min_op_temp,-40
+opa363,OPA4364,max_op_temp,125
+opa363,OPA4364AID,part_family,N
+opa363,OPA4364AID,typ_gbp,7.0 MHz
+opa363,OPA4364AID,typ_supply_current,650.0 uA
+opa363,OPA4364AID,typ_supply_current,850.0 uA
+opa363,OPA4364AID,typ_supply_current,1.1 mA
+opa363,OPA4364AID,min_op_supply_volt,1.8 V
+opa363,OPA4364AID,max_op_supply_volt,5.5 V
+opa363,OPA4364AID,min_op_temp,-40
+opa363,OPA4364AID,max_op_temp,125
+opa363,OPA4364AIDG4,part_family,N
+opa363,OPA4364AIDG4,typ_gbp,7.0 MHz
+opa363,OPA4364AIDG4,typ_supply_current,650.0 uA
+opa363,OPA4364AIDG4,typ_supply_current,850.0 uA
+opa363,OPA4364AIDG4,typ_supply_current,1.1 mA
+opa363,OPA4364AIDG4,min_op_supply_volt,1.8 V
+opa363,OPA4364AIDG4,max_op_supply_volt,5.5 V
+opa363,OPA4364AIDG4,min_op_temp,-40
+opa363,OPA4364AIDG4,max_op_temp,125
+opa363,OPA4364AIDR,part_family,N
+opa363,OPA4364AIDR,typ_gbp,7.0 MHz
+opa363,OPA4364AIDR,typ_supply_current,650.0 uA
+opa363,OPA4364AIDR,typ_supply_current,850.0 uA
+opa363,OPA4364AIDR,typ_supply_current,1.1 mA
+opa363,OPA4364AIDR,min_op_supply_volt,1.8 V
+opa363,OPA4364AIDR,max_op_supply_volt,5.5 V
+opa363,OPA4364AIDR,min_op_temp,-40
+opa363,OPA4364AIDR,max_op_temp,125
+opa363,OPA4364AIDRG4,part_family,N
+opa363,OPA4364AIDRG4,typ_gbp,7.0 MHz
+opa363,OPA4364AIDRG4,typ_supply_current,650.0 uA
+opa363,OPA4364AIDRG4,typ_supply_current,850.0 uA
+opa363,OPA4364AIDRG4,typ_supply_current,1.1 mA
+opa363,OPA4364AIDRG4,min_op_supply_volt,1.8 V
+opa363,OPA4364AIDRG4,max_op_supply_volt,5.5 V
+opa363,OPA4364AIDRG4,min_op_temp,-40
+opa363,OPA4364AIDRG4,max_op_temp,125
+opa363,OPA4364AIPWR,part_family,N
+opa363,OPA4364AIPWR,typ_gbp,7.0 MHz
+opa363,OPA4364AIPWR,typ_supply_current,650.0 uA
+opa363,OPA4364AIPWR,typ_supply_current,850.0 uA
+opa363,OPA4364AIPWR,typ_supply_current,1.1 mA
+opa363,OPA4364AIPWR,min_op_supply_volt,1.8 V
+opa363,OPA4364AIPWR,max_op_supply_volt,5.5 V
+opa363,OPA4364AIPWR,min_op_temp,-40
+opa363,OPA4364AIPWR,max_op_temp,125
+opa363,OPA4364AIPWRG4,part_family,N
+opa363,OPA4364AIPWRG4,typ_gbp,7.0 MHz
+opa363,OPA4364AIPWRG4,typ_supply_current,650.0 uA
+opa363,OPA4364AIPWRG4,typ_supply_current,850.0 uA
+opa363,OPA4364AIPWRG4,typ_supply_current,1.1 mA
+opa363,OPA4364AIPWRG4,min_op_supply_volt,1.8 V
+opa363,OPA4364AIPWRG4,max_op_supply_volt,5.5 V
+opa363,OPA4364AIPWRG4,min_op_temp,-40
+opa363,OPA4364AIPWRG4,max_op_temp,125
+opa363,OPA4364AIPWT,part_family,N
+opa363,OPA4364AIPWT,typ_gbp,7.0 MHz
+opa363,OPA4364AIPWT,typ_supply_current,650.0 uA
+opa363,OPA4364AIPWT,typ_supply_current,850.0 uA
+opa363,OPA4364AIPWT,typ_supply_current,1.1 mA
+opa363,OPA4364AIPWT,min_op_supply_volt,1.8 V
+opa363,OPA4364AIPWT,max_op_supply_volt,5.5 V
+opa363,OPA4364AIPWT,min_op_temp,-40
+opa363,OPA4364AIPWT,max_op_temp,125
+opa363,OPA4364AIPWTG4,part_family,N
+opa363,OPA4364AIPWTG4,typ_gbp,7.0 MHz
+opa363,OPA4364AIPWTG4,typ_supply_current,650.0 uA
+opa363,OPA4364AIPWTG4,typ_supply_current,850.0 uA
+opa363,OPA4364AIPWTG4,typ_supply_current,1.1 mA
+opa363,OPA4364AIPWTG4,min_op_supply_volt,1.8 V
+opa363,OPA4364AIPWTG4,max_op_supply_volt,5.5 V
+opa363,OPA4364AIPWTG4,min_op_temp,-40
+opa363,OPA4364AIPWTG4,max_op_temp,125
+rcv420,RCV420,part_family,Y
+rcv420,RCV420,typ_gbp,150.0 kHz
+rcv420,RCV420,typ_supply_current,3.0 mA
+rcv420,RCV420,min_op_supply_volt,-5 V
+rcv420,RCV420,min_op_supply_volt,11.4 V
+rcv420,RCV420,max_op_supply_volt,±18 V
+rcv420,RCV420,min_op_temp,0
+rcv420,RCV420,max_op_temp,70
+rcv420,RCV420KP,part_family,N
+rcv420,RCV420KP,typ_gbp,150.0 kHz
+rcv420,RCV420KP,typ_supply_current,3.0 mA
+rcv420,RCV420KP,min_op_supply_volt,-5 V
+rcv420,RCV420KP,min_op_supply_volt,11.4 V
+rcv420,RCV420KP,max_op_supply_volt,±18 V
+rcv420,RCV420KP,min_op_temp,0
+rcv420,RCV420KP,max_op_temp,70
+rcv420,RCV420JP,part_family,N
+rcv420,RCV420JP,typ_gbp,150.0 kHz
+rcv420,RCV420JP,typ_supply_current,3.0 mA
+rcv420,RCV420JP,min_op_supply_volt,-5 V
+rcv420,RCV420JP,min_op_supply_volt,11.4 V
+rcv420,RCV420JP,max_op_supply_volt,±18 V
+rcv420,RCV420JP,min_op_temp,0
+rcv420,RCV420JP,max_op_temp,70
+ths3001,THS3001,part_family,Y
+ths3001,THS3001,typ_supply_current,5.5 mA
+ths3001,THS3001,typ_supply_current,6.6 mA
+ths3001,THS3001,min_op_temp,-40
+ths3001,THS3001,max_op_temp,85
+ths3001,THS3001CD,part_family,N
+ths3001,THS3001CD,typ_supply_current,5.5 mA
+ths3001,THS3001CD,typ_supply_current,6.6 mA
+ths3001,THS3001CD,min_op_supply_volt,9 V
+ths3001,THS3001CD,min_op_supply_volt,±4.5 V
+ths3001,THS3001CD,max_op_supply_volt,32 V
+ths3001,THS3001CD,max_op_supply_volt,±16 V
+ths3001,THS3001CD,min_op_temp,0
+ths3001,THS3001CD,max_op_temp,70
+ths3001,THS3001CDG4,part_family,N
+ths3001,THS3001CDG4,typ_supply_current,5.5 mA
+ths3001,THS3001CDG4,typ_supply_current,6.6 mA
+ths3001,THS3001CDG4,min_op_supply_volt,9 V
+ths3001,THS3001CDG4,min_op_supply_volt,±4.5 V
+ths3001,THS3001CDG4,max_op_supply_volt,32 V
+ths3001,THS3001CDG4,max_op_supply_volt,±16 V
+ths3001,THS3001CDG4,min_op_temp,0
+ths3001,THS3001CDG4,max_op_temp,70
+ths3001,THS3001CDGN,part_family,N
+ths3001,THS3001CDGN,typ_supply_current,5.5 mA
+ths3001,THS3001CDGN,typ_supply_current,6.6 mA
+ths3001,THS3001CDGN,min_op_supply_volt,9 V
+ths3001,THS3001CDGN,min_op_supply_volt,±4.5 V
+ths3001,THS3001CDGN,max_op_supply_volt,32 V
+ths3001,THS3001CDGN,max_op_supply_volt,±16 V
+ths3001,THS3001CDGN,min_op_temp,0
+ths3001,THS3001CDGN,max_op_temp,70
+ths3001,THS3001CDGNG4,part_family,N
+ths3001,THS3001CDGNG4,typ_supply_current,5.5 mA
+ths3001,THS3001CDGNG4,typ_supply_current,6.6 mA
+ths3001,THS3001CDGNG4,min_op_supply_volt,9 V
+ths3001,THS3001CDGNG4,min_op_supply_volt,±4.5 V
+ths3001,THS3001CDGNG4,max_op_supply_volt,32 V
+ths3001,THS3001CDGNG4,max_op_supply_volt,±16 V
+ths3001,THS3001CDGNG4,min_op_temp,0
+ths3001,THS3001CDGNG4,max_op_temp,70
+ths3001,THS3001CDGNR,part_family,N
+ths3001,THS3001CDGNR,typ_supply_current,5.5 mA
+ths3001,THS3001CDGNR,typ_supply_current,6.6 mA
+ths3001,THS3001CDGNR,min_op_supply_volt,9 V
+ths3001,THS3001CDGNR,min_op_supply_volt,±4.5 V
+ths3001,THS3001CDGNR,max_op_supply_volt,32 V
+ths3001,THS3001CDGNR,max_op_supply_volt,±16 V
+ths3001,THS3001CDGNR,min_op_temp,0
+ths3001,THS3001CDGNR,max_op_temp,70
+ths3001,THS3001CDR,part_family,N
+ths3001,THS3001CDR,typ_supply_current,5.5 mA
+ths3001,THS3001CDR,typ_supply_current,6.6 mA
+ths3001,THS3001CDR,min_op_supply_volt,9 V
+ths3001,THS3001CDR,min_op_supply_volt,±4.5 V
+ths3001,THS3001CDR,max_op_supply_volt,32 V
+ths3001,THS3001CDR,max_op_supply_volt,±16 V
+ths3001,THS3001CDR,min_op_temp,0
+ths3001,THS3001CDR,max_op_temp,70
+ths3001,THS3001CDRG4,part_family,N
+ths3001,THS3001CDRG4,typ_supply_current,5.5 mA
+ths3001,THS3001CDRG4,typ_supply_current,6.6 mA
+ths3001,THS3001CDRG4,min_op_supply_volt,9 V
+ths3001,THS3001CDRG4,min_op_supply_volt,±4.5 V
+ths3001,THS3001CDRG4,max_op_supply_volt,32 V
+ths3001,THS3001CDRG4,max_op_supply_volt,±16 V
+ths3001,THS3001CDRG4,min_op_temp,0
+ths3001,THS3001CDRG4,max_op_temp,70
+ths3001,THS3001HVCDGN,part_family,N
+ths3001,THS3001HVCDGN,typ_supply_current,5.5 mA
+ths3001,THS3001HVCDGN,typ_supply_current,6.6 mA
+ths3001,THS3001HVCDGN,typ_supply_current,6.9 mA
+ths3001,THS3001HVCDGN,min_op_supply_volt,9 V
+ths3001,THS3001HVCDGN,min_op_supply_volt,±4.5 V
+ths3001,THS3001HVCDGN,max_op_supply_volt,37 V
+ths3001,THS3001HVCDGN,max_op_supply_volt,±18.5 V
+ths3001,THS3001HVCDGN,min_op_temp,0
+ths3001,THS3001HVCDGN,max_op_temp,70
+ths3001,THS3001HVIDGN,part_family,N
+ths3001,THS3001HVIDGN,typ_supply_current,5.5 mA
+ths3001,THS3001HVIDGN,typ_supply_current,6.6 mA
+ths3001,THS3001HVIDGN,typ_supply_current,6.9 mA
+ths3001,THS3001HVIDGN,min_op_supply_volt,9 V
+ths3001,THS3001HVIDGN,min_op_supply_volt,±4.5 V
+ths3001,THS3001HVIDGN,max_op_supply_volt,37 V
+ths3001,THS3001HVIDGN,max_op_supply_volt,±18.5 V
+ths3001,THS3001HVIDGN,min_op_temp,-40
+ths3001,THS3001HVIDGN,max_op_temp,85
+ths3001,THS3001HVIDVNG4,part_family,N
+ths3001,THS3001HVIDVNG4,typ_supply_current,5.5 mA
+ths3001,THS3001HVIDVNG4,typ_supply_current,6.6 mA
+ths3001,THS3001HVIDVNG4,typ_supply_current,6.9 mA
+ths3001,THS3001HVIDVNG4,min_op_supply_volt,9 V
+ths3001,THS3001HVIDVNG4,min_op_supply_volt,±4.5 V
+ths3001,THS3001HVIDVNG4,max_op_supply_volt,37 V
+ths3001,THS3001HVIDVNG4,max_op_supply_volt,±18.5 V
+ths3001,THS3001HVIDVNG4,min_op_temp,-40
+ths3001,THS3001HVIDVNG4,max_op_temp,85
+ths3001,THS3001ID,part_family,N
+ths3001,THS3001ID,typ_supply_current,5.5 mA
+ths3001,THS3001ID,typ_supply_current,6.6 mA
+ths3001,THS3001ID,min_op_supply_volt,9 V
+ths3001,THS3001ID,min_op_supply_volt,±4.5 V
+ths3001,THS3001ID,max_op_supply_volt,32 V
+ths3001,THS3001ID,max_op_supply_volt,±16 V
+ths3001,THS3001ID,min_op_temp,-40
+ths3001,THS3001ID,max_op_temp,85
+ths3001,THS3001IDG4,part_family,N
+ths3001,THS3001IDG4,typ_supply_current,5.5 mA
+ths3001,THS3001IDG4,typ_supply_current,6.6 mA
+ths3001,THS3001IDG4,min_op_supply_volt,9 V
+ths3001,THS3001IDG4,min_op_supply_volt,±4.5 V
+ths3001,THS3001IDG4,max_op_supply_volt,32 V
+ths3001,THS3001IDG4,max_op_supply_volt,±16 V
+ths3001,THS3001IDG4,min_op_temp,-40
+ths3001,THS3001IDG4,max_op_temp,85
+ths3001,THS3001IDGN,part_family,N
+ths3001,THS3001IDGN,typ_supply_current,5.5 mA
+ths3001,THS3001IDGN,typ_supply_current,6.6 mA
+ths3001,THS3001IDGN,min_op_supply_volt,9 V
+ths3001,THS3001IDGN,min_op_supply_volt,±4.5 V
+ths3001,THS3001IDGN,max_op_supply_volt,32 V
+ths3001,THS3001IDGN,max_op_supply_volt,±16 V
+ths3001,THS3001IDGN,min_op_temp,-40
+ths3001,THS3001IDGN,max_op_temp,85
+ths3001,THS3001IDGNG4,part_family,N
+ths3001,THS3001IDGNG4,typ_supply_current,5.5 mA
+ths3001,THS3001IDGNG4,typ_supply_current,6.6 mA
+ths3001,THS3001IDGNG4,min_op_supply_volt,9 V
+ths3001,THS3001IDGNG4,min_op_supply_volt,±4.5 V
+ths3001,THS3001IDGNG4,max_op_supply_volt,32 V
+ths3001,THS3001IDGNG4,max_op_supply_volt,±16 V
+ths3001,THS3001IDGNG4,min_op_temp,-40
+ths3001,THS3001IDGNG4,max_op_temp,85
+ths3001,THS3001IDGNR,part_family,N
+ths3001,THS3001IDGNR,typ_supply_current,5.5 mA
+ths3001,THS3001IDGNR,typ_supply_current,6.6 mA
+ths3001,THS3001IDGNR,min_op_supply_volt,9 V
+ths3001,THS3001IDGNR,min_op_supply_volt,±4.5 V
+ths3001,THS3001IDGNR,max_op_supply_volt,32 V
+ths3001,THS3001IDGNR,max_op_supply_volt,±16 V
+ths3001,THS3001IDGNR,min_op_temp,-40
+ths3001,THS3001IDGNR,max_op_temp,85
+ths3001,THS3001IDR,part_family,N
+ths3001,THS3001IDR,typ_supply_current,5.5 mA
+ths3001,THS3001IDR,typ_supply_current,6.6 mA
+ths3001,THS3001IDR,min_op_supply_volt,9 V
+ths3001,THS3001IDR,min_op_supply_volt,±4.5 V
+ths3001,THS3001IDR,max_op_supply_volt,32 V
+ths3001,THS3001IDR,max_op_supply_volt,±16 V
+ths3001,THS3001IDR,min_op_temp,-40
+ths3001,THS3001IDR,max_op_temp,85
+ths4062,THS4061,part_family,Y
+ths4062,THS4061,typ_supply_current,7.3 mA
+ths4062,THS4061,typ_supply_current,7.8 mA
+ths4062,THS4061,min_op_supply_volt,9 V
+ths4062,THS4061,min_op_supply_volt,±4.5 V
+ths4062,THS4061,max_op_supply_volt,32 V
+ths4062,THS4061,max_op_supply_volt,±16 V
+ths4062,THS4061CD,part_family,N
+ths4062,THS4061CD,typ_supply_current,7.3 mA
+ths4062,THS4061CD,typ_supply_current,7.8 mA
+ths4062,THS4061CD,min_op_supply_volt,9 V
+ths4062,THS4061CD,min_op_supply_volt,±4.5 V
+ths4062,THS4061CD,max_op_supply_volt,32 V
+ths4062,THS4061CD,max_op_supply_volt,±16 V
+ths4062,THS4061CD,min_op_temp,0
+ths4062,THS4061CD,max_op_temp,70
+ths4062,THS4061CDG4,part_family,N
+ths4062,THS4061CDG4,typ_supply_current,7.3 mA
+ths4062,THS4061CDG4,typ_supply_current,7.8 mA
+ths4062,THS4061CDG4,min_op_supply_volt,9 V
+ths4062,THS4061CDG4,min_op_supply_volt,±4.5 V
+ths4062,THS4061CDG4,max_op_supply_volt,32 V
+ths4062,THS4061CDG4,max_op_supply_volt,±16 V
+ths4062,THS4061CDG4,min_op_temp,0
+ths4062,THS4061CDG4,max_op_temp,70
+ths4062,THS4061CDGN,part_family,N
+ths4062,THS4061CDGN,typ_supply_current,7.3 mA
+ths4062,THS4061CDGN,typ_supply_current,7.8 mA
+ths4062,THS4061CDGN,min_op_supply_volt,9 V
+ths4062,THS4061CDGN,min_op_supply_volt,±4.5 V
+ths4062,THS4061CDGN,max_op_supply_volt,32 V
+ths4062,THS4061CDGN,max_op_supply_volt,±16 V
+ths4062,THS4061CDGN,min_op_temp,0
+ths4062,THS4061CDGN,max_op_temp,70
+ths4062,THS4061CDGNR,part_family,N
+ths4062,THS4061CDGNR,typ_supply_current,7.3 mA
+ths4062,THS4061CDGNR,typ_supply_current,7.8 mA
+ths4062,THS4061CDGNR,min_op_supply_volt,9 V
+ths4062,THS4061CDGNR,min_op_supply_volt,±4.5 V
+ths4062,THS4061CDGNR,max_op_supply_volt,32 V
+ths4062,THS4061CDGNR,max_op_supply_volt,±16 V
+ths4062,THS4061CDGNR,min_op_temp,0
+ths4062,THS4061CDGNR,max_op_temp,70
+ths4062,THS4061CDR,part_family,N
+ths4062,THS4061CDR,typ_supply_current,7.3 mA
+ths4062,THS4061CDR,typ_supply_current,7.8 mA
+ths4062,THS4061CDR,min_op_supply_volt,9 V
+ths4062,THS4061CDR,min_op_supply_volt,±4.5 V
+ths4062,THS4061CDR,max_op_supply_volt,32 V
+ths4062,THS4061CDR,max_op_supply_volt,±16 V
+ths4062,THS4061CDR,min_op_temp,0
+ths4062,THS4061CDR,max_op_temp,70
+ths4062,THS4061ID,part_family,N
+ths4062,THS4061ID,typ_supply_current,7.3 mA
+ths4062,THS4061ID,typ_supply_current,7.8 mA
+ths4062,THS4061ID,min_op_supply_volt,9 V
+ths4062,THS4061ID,min_op_supply_volt,±4.5 V
+ths4062,THS4061ID,max_op_supply_volt,32 V
+ths4062,THS4061ID,max_op_supply_volt,±16 V
+ths4062,THS4061ID,min_op_temp,-40
+ths4062,THS4061ID,max_op_temp,85
+ths4062,THS4061IDG4,part_family,N
+ths4062,THS4061IDG4,typ_supply_current,7.3 mA
+ths4062,THS4061IDG4,typ_supply_current,7.8 mA
+ths4062,THS4061IDG4,min_op_supply_volt,9 V
+ths4062,THS4061IDG4,min_op_supply_volt,±4.5 V
+ths4062,THS4061IDG4,max_op_supply_volt,32 V
+ths4062,THS4061IDG4,max_op_supply_volt,±16 V
+ths4062,THS4061IDG4,min_op_temp,-40
+ths4062,THS4061IDG4,max_op_temp,85
+ths4062,THS4061IDGNR,part_family,N
+ths4062,THS4061IDGNR,typ_supply_current,7.3 mA
+ths4062,THS4061IDGNR,typ_supply_current,7.8 mA
+ths4062,THS4061IDGNR,min_op_supply_volt,9 V
+ths4062,THS4061IDGNR,min_op_supply_volt,±4.5 V
+ths4062,THS4061IDGNR,max_op_supply_volt,32 V
+ths4062,THS4061IDGNR,max_op_supply_volt,±16 V
+ths4062,THS4061IDGNR,min_op_temp,-40
+ths4062,THS4061IDGNR,max_op_temp,85
+ths4062,THS4061IDR,part_family,N
+ths4062,THS4061IDR,typ_supply_current,7.3 mA
+ths4062,THS4061IDR,typ_supply_current,7.8 mA
+ths4062,THS4061IDR,min_op_supply_volt,9 V
+ths4062,THS4061IDR,min_op_supply_volt,±4.5 V
+ths4062,THS4061IDR,max_op_supply_volt,32 V
+ths4062,THS4061IDR,max_op_supply_volt,±16 V
+ths4062,THS4061IDR,min_op_temp,-40
+ths4062,THS4061IDR,max_op_temp,85
+ths4062,THS4061IDRG4,part_family,N
+ths4062,THS4061IDRG4,typ_supply_current,7.3 mA
+ths4062,THS4061IDRG4,typ_supply_current,7.8 mA
+ths4062,THS4061IDRG4,min_op_supply_volt,9 V
+ths4062,THS4061IDRG4,min_op_supply_volt,±4.5 V
+ths4062,THS4061IDRG4,max_op_supply_volt,32 V
+ths4062,THS4061IDRG4,max_op_supply_volt,±16 V
+ths4062,THS4061IDRG4,min_op_temp,-40
+ths4062,THS4061IDRG4,max_op_temp,85
+ths4062,THS4061MFKB,part_family,N
+ths4062,THS4061MFKB,typ_supply_current,7.3 mA
+ths4062,THS4061MFKB,typ_supply_current,7.8 mA
+ths4062,THS4061MFKB,min_op_supply_volt,9 V
+ths4062,THS4061MFKB,min_op_supply_volt,±4.5 V
+ths4062,THS4061MFKB,max_op_supply_volt,32 V
+ths4062,THS4061MFKB,max_op_supply_volt,±16 V
+ths4062,THS4061MFKB,min_op_temp,-55
+ths4062,THS4061MFKB,max_op_temp,125
+ths4062,THS4061MJG,part_family,N
+ths4062,THS4061MJG,typ_supply_current,7.3 mA
+ths4062,THS4061MJG,typ_supply_current,7.8 mA
+ths4062,THS4061MJG,min_op_supply_volt,9 V
+ths4062,THS4061MJG,min_op_supply_volt,±4.5 V
+ths4062,THS4061MJG,max_op_supply_volt,32 V
+ths4062,THS4061MJG,max_op_supply_volt,±16 V
+ths4062,THS4061MJG,min_op_temp,-55
+ths4062,THS4061MJG,max_op_temp,125
+ths4062,THS4061MJGB,part_family,N
+ths4062,THS4061MJGB,typ_supply_current,7.3 mA
+ths4062,THS4061MJGB,typ_supply_current,7.8 mA
+ths4062,THS4061MJGB,min_op_supply_volt,9 V
+ths4062,THS4061MJGB,min_op_supply_volt,±4.5 V
+ths4062,THS4061MJGB,max_op_supply_volt,32 V
+ths4062,THS4061MJGB,max_op_supply_volt,±16 V
+ths4062,THS4061MJGB,min_op_temp,-55
+ths4062,THS4061MJGB,max_op_temp,125
+ths4062,THS4062,part_family,Y
+ths4062,THS4062,typ_supply_current,7.3 mA
+ths4062,THS4062,typ_supply_current,7.8 mA
+ths4062,THS4062,min_op_supply_volt,9 V
+ths4062,THS4062,min_op_supply_volt,±4.5 V
+ths4062,THS4062,max_op_supply_volt,32 V
+ths4062,THS4062,max_op_supply_volt,±16 V
+ths4062,THS4062CD,part_family,N
+ths4062,THS4062CD,typ_supply_current,7.3 mA
+ths4062,THS4062CD,typ_supply_current,7.8 mA
+ths4062,THS4062CD,min_op_supply_volt,9 V
+ths4062,THS4062CD,min_op_supply_volt,±4.5 V
+ths4062,THS4062CD,max_op_supply_volt,32 V
+ths4062,THS4062CD,max_op_supply_volt,±16 V
+ths4062,THS4062CD,min_op_temp,0
+ths4062,THS4062CD,max_op_temp,70
+ths4062,THS4062CDG4,part_family,N
+ths4062,THS4062CDG4,typ_supply_current,7.3 mA
+ths4062,THS4062CDG4,typ_supply_current,7.8 mA
+ths4062,THS4062CDG4,min_op_supply_volt,9 V
+ths4062,THS4062CDG4,min_op_supply_volt,±4.5 V
+ths4062,THS4062CDG4,max_op_supply_volt,32 V
+ths4062,THS4062CDG4,max_op_supply_volt,±16 V
+ths4062,THS4062CDG4,min_op_temp,0
+ths4062,THS4062CDG4,max_op_temp,70
+ths4062,THS4062CDGN,part_family,N
+ths4062,THS4062CDGN,typ_supply_current,7.3 mA
+ths4062,THS4062CDGN,typ_supply_current,7.8 mA
+ths4062,THS4062CDGN,min_op_supply_volt,9 V
+ths4062,THS4062CDGN,min_op_supply_volt,±4.5 V
+ths4062,THS4062CDGN,max_op_supply_volt,32 V
+ths4062,THS4062CDGN,max_op_supply_volt,±16 V
+ths4062,THS4062CDGN,min_op_temp,0
+ths4062,THS4062CDGN,max_op_temp,70
+ths4062,THS4062CDGNG4,part_family,N
+ths4062,THS4062CDGNG4,typ_supply_current,7.3 mA
+ths4062,THS4062CDGNG4,typ_supply_current,7.8 mA
+ths4062,THS4062CDGNG4,min_op_supply_volt,9 V
+ths4062,THS4062CDGNG4,min_op_supply_volt,±4.5 V
+ths4062,THS4062CDGNG4,max_op_supply_volt,32 V
+ths4062,THS4062CDGNG4,max_op_supply_volt,±16 V
+ths4062,THS4062CDGNG4,min_op_temp,0
+ths4062,THS4062CDGNG4,max_op_temp,70
+ths4062,THS4062CDR,part_family,N
+ths4062,THS4062CDR,typ_supply_current,7.3 mA
+ths4062,THS4062CDR,typ_supply_current,7.8 mA
+ths4062,THS4062CDR,min_op_supply_volt,9 V
+ths4062,THS4062CDR,min_op_supply_volt,±4.5 V
+ths4062,THS4062CDR,max_op_supply_volt,32 V
+ths4062,THS4062CDR,max_op_supply_volt,±16 V
+ths4062,THS4062CDR,min_op_temp,0
+ths4062,THS4062CDR,max_op_temp,70
+ths4062,THS4062CDRG4,part_family,N
+ths4062,THS4062CDRG4,typ_supply_current,7.3 mA
+ths4062,THS4062CDRG4,typ_supply_current,7.8 mA
+ths4062,THS4062CDRG4,min_op_supply_volt,9 V
+ths4062,THS4062CDRG4,min_op_supply_volt,±4.5 V
+ths4062,THS4062CDRG4,max_op_supply_volt,32 V
+ths4062,THS4062CDRG4,max_op_supply_volt,±16 V
+ths4062,THS4062CDRG4,min_op_temp,0
+ths4062,THS4062CDRG4,max_op_temp,70
+ths4062,THS4062ID,part_family,N
+ths4062,THS4062ID,typ_supply_current,7.3 mA
+ths4062,THS4062ID,typ_supply_current,7.8 mA
+ths4062,THS4062ID,min_op_supply_volt,9 V
+ths4062,THS4062ID,min_op_supply_volt,±4.5 V
+ths4062,THS4062ID,max_op_supply_volt,32 V
+ths4062,THS4062ID,max_op_supply_volt,±16 V
+ths4062,THS4062ID,min_op_temp,-40
+ths4062,THS4062ID,max_op_temp,85
+ths4062,THS4062IDG4,part_family,N
+ths4062,THS4062IDG4,typ_supply_current,7.3 mA
+ths4062,THS4062IDG4,typ_supply_current,7.8 mA
+ths4062,THS4062IDG4,min_op_supply_volt,9 V
+ths4062,THS4062IDG4,min_op_supply_volt,±4.5 V
+ths4062,THS4062IDG4,max_op_supply_volt,32 V
+ths4062,THS4062IDG4,max_op_supply_volt,±16 V
+ths4062,THS4062IDG4,min_op_temp,-40
+ths4062,THS4062IDG4,max_op_temp,85
+ths4062,THS4062IDGN,part_family,N
+ths4062,THS4062IDGN,typ_supply_current,7.3 mA
+ths4062,THS4062IDGN,typ_supply_current,7.8 mA
+ths4062,THS4062IDGN,min_op_supply_volt,9 V
+ths4062,THS4062IDGN,min_op_supply_volt,±4.5 V
+ths4062,THS4062IDGN,max_op_supply_volt,32 V
+ths4062,THS4062IDGN,max_op_supply_volt,±16 V
+ths4062,THS4062IDGN,min_op_temp,-40
+ths4062,THS4062IDGN,max_op_temp,85
+ths4062,THS4062IDGNR,part_family,N
+ths4062,THS4062IDGNR,typ_supply_current,7.3 mA
+ths4062,THS4062IDGNR,typ_supply_current,7.8 mA
+ths4062,THS4062IDGNR,min_op_supply_volt,9 V
+ths4062,THS4062IDGNR,min_op_supply_volt,±4.5 V
+ths4062,THS4062IDGNR,max_op_supply_volt,32 V
+ths4062,THS4062IDGNR,max_op_supply_volt,±16 V
+ths4062,THS4062IDGNR,min_op_temp,-40
+ths4062,THS4062IDGNR,max_op_temp,85
+ths4062,THS4062IDGNRG4,part_family,N
+ths4062,THS4062IDGNRG4,typ_supply_current,7.3 mA
+ths4062,THS4062IDGNRG4,typ_supply_current,7.8 mA
+ths4062,THS4062IDGNRG4,min_op_supply_volt,9 V
+ths4062,THS4062IDGNRG4,min_op_supply_volt,±4.5 V
+ths4062,THS4062IDGNRG4,max_op_supply_volt,32 V
+ths4062,THS4062IDGNRG4,max_op_supply_volt,±16 V
+ths4062,THS4062IDGNRG4,min_op_temp,-40
+ths4062,THS4062IDGNRG4,max_op_temp,85
+ths4062,THS4062IDR,part_family,N
+ths4062,THS4062IDR,typ_supply_current,7.3 mA
+ths4062,THS4062IDR,typ_supply_current,7.8 mA
+ths4062,THS4062IDR,min_op_supply_volt,9 V
+ths4062,THS4062IDR,min_op_supply_volt,±4.5 V
+ths4062,THS4062IDR,max_op_supply_volt,32 V
+ths4062,THS4062IDR,max_op_supply_volt,±16 V
+ths4062,THS4062IDR,min_op_temp,-40
+ths4062,THS4062IDR,max_op_temp,85
+ths4062,5962-9960101Q2A,part_family,N
+ths4062,5962-9960101Q2A,typ_supply_current,7.3 mA
+ths4062,5962-9960101Q2A,typ_supply_current,7.8 mA
+ths4062,5962-9960101Q2A,min_op_supply_volt,9 V
+ths4062,5962-9960101Q2A,min_op_supply_volt,±4.5 V
+ths4062,5962-9960101Q2A,max_op_supply_volt,32 V
+ths4062,5962-9960101Q2A,max_op_supply_volt,±16 V
+ths4062,5962-9960101Q2A,min_op_temp,-55
+ths4062,5962-9960101Q2A,max_op_temp,125
+ths4062,5962-9960101QPA,part_family,N
+ths4062,5962-9960101QPA,typ_supply_current,7.3 mA
+ths4062,5962-9960101QPA,typ_supply_current,7.8 mA
+ths4062,5962-9960101QPA,min_op_supply_volt,9 V
+ths4062,5962-9960101QPA,min_op_supply_volt,±4.5 V
+ths4062,5962-9960101QPA,max_op_supply_volt,32 V
+ths4062,5962-9960101QPA,max_op_supply_volt,±16 V
+ths4062,5962-9960101QPA,min_op_temp,-55
+ths4062,5962-9960101QPA,max_op_temp,125
+ths4211,THS4211,part_family,Y
+ths4211,THS4211,typ_gbp,350.0 MHz
+ths4211,THS4211,typ_gbp,300.0 MHz
+ths4211,THS4211,typ_supply_current,19.0 mA
+ths4211,THS4211,min_op_supply_volt,5 V
+ths4211,THS4211,min_op_supply_volt,±2.5 V
+ths4211,THS4211,max_op_supply_volt,15 V
+ths4211,THS4211,max_op_supply_volt,±7.5 V
+ths4211,THS4211,min_op_temp,-40
+ths4211,THS4211,max_op_temp,85
+ths4211,THS4211D,part_family,N
+ths4211,THS4211D,typ_gbp,350.0 MHz
+ths4211,THS4211D,typ_gbp,300.0 MHz
+ths4211,THS4211D,typ_supply_current,19.0 mA
+ths4211,THS4211D,min_op_supply_volt,5 V
+ths4211,THS4211D,min_op_supply_volt,±2.5 V
+ths4211,THS4211D,max_op_supply_volt,15 V
+ths4211,THS4211D,max_op_supply_volt,±7.5 V
+ths4211,THS4211D,min_op_temp,-40
+ths4211,THS4211D,max_op_temp,85
+ths4211,THS4211DG4,part_family,N
+ths4211,THS4211DG4,typ_gbp,350.0 MHz
+ths4211,THS4211DG4,typ_gbp,300.0 MHz
+ths4211,THS4211DG4,typ_supply_current,19.0 mA
+ths4211,THS4211DG4,min_op_supply_volt,5 V
+ths4211,THS4211DG4,min_op_supply_volt,±2.5 V
+ths4211,THS4211DG4,max_op_supply_volt,15 V
+ths4211,THS4211DG4,max_op_supply_volt,±7.5 V
+ths4211,THS4211DG4,min_op_temp,-40
+ths4211,THS4211DG4,max_op_temp,85
+ths4211,THS4211DGK,part_family,N
+ths4211,THS4211DGK,typ_gbp,350.0 MHz
+ths4211,THS4211DGK,typ_gbp,300.0 MHz
+ths4211,THS4211DGK,typ_supply_current,19.0 mA
+ths4211,THS4211DGK,min_op_supply_volt,5 V
+ths4211,THS4211DGK,min_op_supply_volt,±2.5 V
+ths4211,THS4211DGK,max_op_supply_volt,15 V
+ths4211,THS4211DGK,max_op_supply_volt,±7.5 V
+ths4211,THS4211DGK,min_op_temp,-40
+ths4211,THS4211DGK,max_op_temp,85
+ths4211,THS4211DGKR,part_family,N
+ths4211,THS4211DGKR,typ_gbp,350.0 MHz
+ths4211,THS4211DGKR,typ_gbp,300.0 MHz
+ths4211,THS4211DGKR,typ_supply_current,19.0 mA
+ths4211,THS4211DGKR,min_op_supply_volt,5 V
+ths4211,THS4211DGKR,min_op_supply_volt,±2.5 V
+ths4211,THS4211DGKR,max_op_supply_volt,15 V
+ths4211,THS4211DGKR,max_op_supply_volt,±7.5 V
+ths4211,THS4211DGKR,min_op_temp,-40
+ths4211,THS4211DGKR,max_op_temp,85
+ths4211,THS4211DGN,part_family,N
+ths4211,THS4211DGN,typ_gbp,350.0 MHz
+ths4211,THS4211DGN,typ_gbp,300.0 MHz
+ths4211,THS4211DGN,typ_supply_current,19.0 mA
+ths4211,THS4211DGN,min_op_supply_volt,5 V
+ths4211,THS4211DGN,min_op_supply_volt,±2.5 V
+ths4211,THS4211DGN,max_op_supply_volt,15 V
+ths4211,THS4211DGN,max_op_supply_volt,±7.5 V
+ths4211,THS4211DGN,min_op_temp,-40
+ths4211,THS4211DGN,max_op_temp,85
+ths4211,THS4211DGNR,part_family,N
+ths4211,THS4211DGNR,typ_gbp,350.0 MHz
+ths4211,THS4211DGNR,typ_gbp,300.0 MHz
+ths4211,THS4211DGNR,typ_supply_current,19.0 mA
+ths4211,THS4211DGNR,min_op_supply_volt,5 V
+ths4211,THS4211DGNR,min_op_supply_volt,±2.5 V
+ths4211,THS4211DGNR,max_op_supply_volt,15 V
+ths4211,THS4211DGNR,max_op_supply_volt,±7.5 V
+ths4211,THS4211DGNR,min_op_temp,-40
+ths4211,THS4211DGNR,max_op_temp,85
+ths4211,THS4211DGNRG4,part_family,N
+ths4211,THS4211DGNRG4,typ_gbp,350.0 MHz
+ths4211,THS4211DGNRG4,typ_gbp,300.0 MHz
+ths4211,THS4211DGNRG4,typ_supply_current,19.0 mA
+ths4211,THS4211DGNRG4,min_op_supply_volt,5 V
+ths4211,THS4211DGNRG4,min_op_supply_volt,±2.5 V
+ths4211,THS4211DGNRG4,max_op_supply_volt,15 V
+ths4211,THS4211DGNRG4,max_op_supply_volt,±7.5 V
+ths4211,THS4211DGNRG4,min_op_temp,-40
+ths4211,THS4211DGNRG4,max_op_temp,85
+ths4211,THS4211DR,part_family,N
+ths4211,THS4211DR,typ_gbp,350.0 MHz
+ths4211,THS4211DR,typ_gbp,300.0 MHz
+ths4211,THS4211DR,typ_supply_current,19.0 mA
+ths4211,THS4211DR,min_op_supply_volt,5 V
+ths4211,THS4211DR,min_op_supply_volt,±2.5 V
+ths4211,THS4211DR,max_op_supply_volt,15 V
+ths4211,THS4211DR,max_op_supply_volt,±7.5 V
+ths4211,THS4211DR,min_op_temp,-40
+ths4211,THS4211DR,max_op_temp,85
+ths4211,THS4211DRBR,part_family,N
+ths4211,THS4211DRBR,typ_gbp,350.0 MHz
+ths4211,THS4211DRBR,typ_gbp,300.0 MHz
+ths4211,THS4211DRBR,typ_supply_current,19.0 mA
+ths4211,THS4211DRBR,min_op_supply_volt,5 V
+ths4211,THS4211DRBR,min_op_supply_volt,±2.5 V
+ths4211,THS4211DRBR,max_op_supply_volt,15 V
+ths4211,THS4211DRBR,max_op_supply_volt,±7.5 V
+ths4211,THS4211DRBR,min_op_temp,-40
+ths4211,THS4211DRBR,max_op_temp,85
+ths4211,THS4211DRBT,part_family,N
+ths4211,THS4211DRBT,typ_gbp,350.0 MHz
+ths4211,THS4211DRBT,typ_gbp,300.0 MHz
+ths4211,THS4211DRBT,typ_supply_current,19.0 mA
+ths4211,THS4211DRBT,min_op_supply_volt,5 V
+ths4211,THS4211DRBT,min_op_supply_volt,±2.5 V
+ths4211,THS4211DRBT,max_op_supply_volt,15 V
+ths4211,THS4211DRBT,max_op_supply_volt,±7.5 V
+ths4211,THS4211DRBT,min_op_temp,-40
+ths4211,THS4211DRBT,max_op_temp,85
+ths4211,THS4211DRBTG4,part_family,N
+ths4211,THS4211DRBTG4,typ_gbp,350.0 MHz
+ths4211,THS4211DRBTG4,typ_gbp,300.0 MHz
+ths4211,THS4211DRBTG4,typ_supply_current,19.0 mA
+ths4211,THS4211DRBTG4,min_op_supply_volt,5 V
+ths4211,THS4211DRBTG4,min_op_supply_volt,±2.5 V
+ths4211,THS4211DRBTG4,max_op_supply_volt,15 V
+ths4211,THS4211DRBTG4,max_op_supply_volt,±7.5 V
+ths4211,THS4211DRBTG4,min_op_temp,-40
+ths4211,THS4211DRBTG4,max_op_temp,85
+ths4211,THS4211DRG4,part_family,N
+ths4211,THS4211DRG4,typ_gbp,350.0 MHz
+ths4211,THS4211DRG4,typ_gbp,300.0 MHz
+ths4211,THS4211DRG4,typ_supply_current,19.0 mA
+ths4211,THS4211DRG4,min_op_supply_volt,5 V
+ths4211,THS4211DRG4,min_op_supply_volt,±2.5 V
+ths4211,THS4211DRG4,max_op_supply_volt,15 V
+ths4211,THS4211DRG4,max_op_supply_volt,±7.5 V
+ths4211,THS4211DRG4,min_op_temp,-40
+ths4211,THS4211DRG4,max_op_temp,85
+ths4211,THS4215,part_family,Y
+ths4211,THS4215,typ_gbp,350.0 MHz
+ths4211,THS4215,typ_gbp,300.0 MHz
+ths4211,THS4215,typ_supply_current,19.0 mA
+ths4211,THS4215,min_op_supply_volt,5 V
+ths4211,THS4215,min_op_supply_volt,±2.5 V
+ths4211,THS4215,max_op_supply_volt,15 V
+ths4211,THS4215,max_op_supply_volt,±7.5 V
+ths4211,THS4215,min_op_temp,-40
+ths4211,THS4215,max_op_temp,85
+ths4211,THS4215D,part_family,N
+ths4211,THS4215D,typ_gbp,350.0 MHz
+ths4211,THS4215D,typ_gbp,300.0 MHz
+ths4211,THS4215D,typ_supply_current,19.0 mA
+ths4211,THS4215D,min_op_supply_volt,5 V
+ths4211,THS4215D,min_op_supply_volt,±2.5 V
+ths4211,THS4215D,max_op_supply_volt,15 V
+ths4211,THS4215D,max_op_supply_volt,±7.5 V
+ths4211,THS4215D,min_op_temp,-40
+ths4211,THS4215D,max_op_temp,85
+ths4211,THS4215DR,part_family,N
+ths4211,THS4215DR,typ_gbp,350.0 MHz
+ths4211,THS4215DR,typ_gbp,300.0 MHz
+ths4211,THS4215DR,typ_supply_current,19.0 mA
+ths4211,THS4215DR,min_op_supply_volt,5 V
+ths4211,THS4215DR,min_op_supply_volt,±2.5 V
+ths4211,THS4215DR,max_op_supply_volt,15 V
+ths4211,THS4215DR,max_op_supply_volt,±7.5 V
+ths4211,THS4215DR,min_op_temp,-40
+ths4211,THS4215DR,max_op_temp,85
+ths4211,THS4215DGK,part_family,N
+ths4211,THS4215DGK,typ_gbp,350.0 MHz
+ths4211,THS4215DGK,typ_gbp,300.0 MHz
+ths4211,THS4215DGK,typ_supply_current,19.0 mA
+ths4211,THS4215DGK,min_op_supply_volt,5 V
+ths4211,THS4215DGK,min_op_supply_volt,±2.5 V
+ths4211,THS4215DGK,max_op_supply_volt,15 V
+ths4211,THS4215DGK,max_op_supply_volt,±7.5 V
+ths4211,THS4215DGK,min_op_temp,-40
+ths4211,THS4215DGK,max_op_temp,85
+ths4211,THS4215DGKR,part_family,N
+ths4211,THS4215DGKR,typ_gbp,350.0 MHz
+ths4211,THS4215DGKR,typ_gbp,300.0 MHz
+ths4211,THS4215DGKR,typ_supply_current,19.0 mA
+ths4211,THS4215DGKR,min_op_supply_volt,5 V
+ths4211,THS4215DGKR,min_op_supply_volt,±2.5 V
+ths4211,THS4215DGKR,max_op_supply_volt,15 V
+ths4211,THS4215DGKR,max_op_supply_volt,±7.5 V
+ths4211,THS4215DGKR,min_op_temp,-40
+ths4211,THS4215DGKR,max_op_temp,85
+ths4211,THS4215DGN,part_family,N
+ths4211,THS4215DGN,typ_gbp,350.0 MHz
+ths4211,THS4215DGN,typ_gbp,300.0 MHz
+ths4211,THS4215DGN,typ_supply_current,19.0 mA
+ths4211,THS4215DGN,min_op_supply_volt,5 V
+ths4211,THS4215DGN,min_op_supply_volt,±2.5 V
+ths4211,THS4215DGN,max_op_supply_volt,15 V
+ths4211,THS4215DGN,max_op_supply_volt,±7.5 V
+ths4211,THS4215DGN,min_op_temp,-40
+ths4211,THS4215DGN,max_op_temp,85
+ths4211,THS4215DRBR,part_family,N
+ths4211,THS4215DRBR,typ_gbp,350.0 MHz
+ths4211,THS4215DRBR,typ_gbp,300.0 MHz
+ths4211,THS4215DRBR,typ_supply_current,19.0 mA
+ths4211,THS4215DRBR,min_op_supply_volt,5 V
+ths4211,THS4215DRBR,min_op_supply_volt,±2.5 V
+ths4211,THS4215DRBR,max_op_supply_volt,15 V
+ths4211,THS4215DRBR,max_op_supply_volt,±7.5 V
+ths4211,THS4215DRBR,min_op_temp,-40
+ths4211,THS4215DRBR,max_op_temp,85
+ths4211,THS4215DRBT,part_family,N
+ths4211,THS4215DRBT,typ_gbp,350.0 MHz
+ths4211,THS4215DRBT,typ_gbp,300.0 MHz
+ths4211,THS4215DRBT,typ_supply_current,19.0 mA
+ths4211,THS4215DRBT,min_op_supply_volt,5 V
+ths4211,THS4215DRBT,min_op_supply_volt,±2.5 V
+ths4211,THS4215DRBT,max_op_supply_volt,15 V
+ths4211,THS4215DRBT,max_op_supply_volt,±7.5 V
+ths4211,THS4215DRBT,min_op_temp,-40
+ths4211,THS4215DRBT,max_op_temp,85
+ths4211,THS4215DGNR,part_family,N
+ths4211,THS4215DGNR,typ_gbp,350.0 MHz
+ths4211,THS4215DGNR,typ_gbp,300.0 MHz
+ths4211,THS4215DGNR,typ_supply_current,19.0 mA
+ths4211,THS4215DGNR,min_op_supply_volt,5 V
+ths4211,THS4215DGNR,min_op_supply_volt,±2.5 V
+ths4211,THS4215DGNR,max_op_supply_volt,15 V
+ths4211,THS4215DGNR,max_op_supply_volt,±7.5 V
+ths4211,THS4215DGNR,min_op_temp,-40
+ths4211,THS4215DGNR,max_op_temp,85
+ths4271-ep,THS4271-EP,part_family,Y
+ths4271-ep,THS4271-EP,typ_gbp,400.0 MHz
+ths4271-ep,THS4271-EP,typ_gbp,350.0 MHz
+ths4271-ep,THS4271-EP,typ_supply_current,22.0 mA
+ths4271-ep,THS4271-EP,min_op_supply_volt,5 V
+ths4271-ep,THS4271-EP,min_op_supply_volt,±2.5 V
+ths4271-ep,THS4271-EP,max_op_supply_volt,10 V
+ths4271-ep,THS4271-EP,max_op_supply_volt,±5 V
+ths4271-ep,THS4271-EP,min_op_temp,-55
+ths4271-ep,THS4271-EP,max_op_temp,125
+ths4271-ep,THS4271MDGNTEP,part_family,N
+ths4271-ep,THS4271MDGNTEP,typ_gbp,400.0 MHz
+ths4271-ep,THS4271MDGNTEP,typ_gbp,350.0 MHz
+ths4271-ep,THS4271MDGNTEP,typ_supply_current,22.0 mA
+ths4271-ep,THS4271MDGNTEP,min_op_supply_volt,5 V
+ths4271-ep,THS4271MDGNTEP,min_op_supply_volt,±2.5 V
+ths4271-ep,THS4271MDGNTEP,max_op_supply_volt,10 V
+ths4271-ep,THS4271MDGNTEP,max_op_supply_volt,±5 V
+ths4271-ep,THS4271MDGNTEP,min_op_temp,-55
+ths4271-ep,THS4271MDGNTEP,max_op_temp,125
+ths4271-ep,THS4271MDGNREP,part_family,N
+ths4271-ep,THS4271MDGNREP,typ_gbp,400.0 MHz
+ths4271-ep,THS4271MDGNREP,typ_gbp,350.0 MHz
+ths4271-ep,THS4271MDGNREP,typ_supply_current,22.0 mA
+ths4271-ep,THS4271MDGNREP,min_op_supply_volt,5 V
+ths4271-ep,THS4271MDGNREP,min_op_supply_volt,±2.5 V
+ths4271-ep,THS4271MDGNREP,max_op_supply_volt,10 V
+ths4271-ep,THS4271MDGNREP,max_op_supply_volt,±5 V
+ths4271-ep,THS4271MDGNREP,min_op_temp,-55
+ths4271-ep,THS4271MDGNREP,max_op_temp,125
+ths4271-ep,V62/05610-01YE,part_family,N
+ths4271-ep,V62/05610-01YE,typ_gbp,400.0 MHz
+ths4271-ep,V62/05610-01YE,typ_gbp,350.0 MHz
+ths4271-ep,V62/05610-01YE,typ_supply_current,22.0 mA
+ths4271-ep,V62/05610-01YE,min_op_supply_volt,5 V
+ths4271-ep,V62/05610-01YE,min_op_supply_volt,±2.5 V
+ths4271-ep,V62/05610-01YE,max_op_supply_volt,10 V
+ths4271-ep,V62/05610-01YE,max_op_supply_volt,±5 V
+ths4271-ep,V62/05610-01YE,min_op_temp,-55
+ths4271-ep,V62/05610-01YE,max_op_temp,125
+tl051,TL051ACD,part_family,N
+tl051,TL051ACD,typ_gbp,3.0 MHz
+tl051,TL051ACD,typ_gbp,3.1 MHz
+tl051,TL051ACD,typ_supply_current,2.6 mA
+tl051,TL051ACD,typ_supply_current,2.7 mA
+tl051,TL051ACD,min_op_supply_volt,±5 V
+tl051,TL051ACD,max_op_supply_volt,±15 V
+tl051,TL051ACD,min_op_temp,0
+tl051,TL051ACD,max_op_temp,70
+tl051,TL051ACDG4,part_family,N
+tl051,TL051ACDG4,typ_gbp,3.0 MHz
+tl051,TL051ACDG4,typ_gbp,3.1 MHz
+tl051,TL051ACDG4,typ_supply_current,2.6 mA
+tl051,TL051ACDG4,typ_supply_current,2.7 mA
+tl051,TL051ACDG4,min_op_supply_volt,±5 V
+tl051,TL051ACDG4,max_op_supply_volt,±15 V
+tl051,TL051ACDG4,min_op_temp,0
+tl051,TL051ACDG4,max_op_temp,70
+tl051,TL051ACP,part_family,N
+tl051,TL051ACP,typ_gbp,3.0 MHz
+tl051,TL051ACP,typ_gbp,3.1 MHz
+tl051,TL051ACP,typ_supply_current,2.6 mA
+tl051,TL051ACP,typ_supply_current,2.7 mA
+tl051,TL051ACP,min_op_supply_volt,±5 V
+tl051,TL051ACP,max_op_supply_volt,±15 V
+tl051,TL051ACP,min_op_temp,0
+tl051,TL051ACP,max_op_temp,70
+tl051,TL051AID,part_family,N
+tl051,TL051AID,typ_gbp,3.0 MHz
+tl051,TL051AID,typ_gbp,3.1 MHz
+tl051,TL051AID,typ_supply_current,2.6 mA
+tl051,TL051AID,typ_supply_current,2.7 mA
+tl051,TL051AID,min_op_supply_volt,±5 V
+tl051,TL051AID,max_op_supply_volt,±15 V
+tl051,TL051AID,min_op_temp,-40
+tl051,TL051AID,max_op_temp,85
+tl051,TL051AIP,part_family,N
+tl051,TL051AIP,typ_gbp,3.0 MHz
+tl051,TL051AIP,typ_gbp,3.1 MHz
+tl051,TL051AIP,typ_supply_current,2.6 mA
+tl051,TL051AIP,typ_supply_current,2.7 mA
+tl051,TL051AIP,min_op_supply_volt,±5 V
+tl051,TL051AIP,max_op_supply_volt,±15 V
+tl051,TL051AIP,min_op_temp,-40
+tl051,TL051AIP,max_op_temp,85
+tl051,TL051CD,part_family,N
+tl051,TL051CD,typ_gbp,3.0 MHz
+tl051,TL051CD,typ_gbp,3.1 MHz
+tl051,TL051CD,typ_supply_current,2.6 mA
+tl051,TL051CD,typ_supply_current,2.7 mA
+tl051,TL051CD,min_op_supply_volt,±5 V
+tl051,TL051CD,max_op_supply_volt,±15 V
+tl051,TL051CD,min_op_temp,0
+tl051,TL051CD,max_op_temp,70
+tl051,TL051CDR,part_family,N
+tl051,TL051CDR,typ_gbp,3.0 MHz
+tl051,TL051CDR,typ_gbp,3.1 MHz
+tl051,TL051CDR,typ_supply_current,2.6 mA
+tl051,TL051CDR,typ_supply_current,2.7 mA
+tl051,TL051CDR,min_op_supply_volt,±5 V
+tl051,TL051CDR,max_op_supply_volt,±15 V
+tl051,TL051CDR,min_op_temp,0
+tl051,TL051CDR,max_op_temp,70
+tl051,TL051CDRG4,part_family,N
+tl051,TL051CDRG4,typ_gbp,3.0 MHz
+tl051,TL051CDRG4,typ_gbp,3.1 MHz
+tl051,TL051CDRG4,typ_supply_current,2.6 mA
+tl051,TL051CDRG4,typ_supply_current,2.7 mA
+tl051,TL051CDRG4,min_op_supply_volt,±5 V
+tl051,TL051CDRG4,max_op_supply_volt,±15 V
+tl051,TL051CDRG4,min_op_temp,0
+tl051,TL051CDRG4,max_op_temp,70
+tl051,TL051CP,part_family,N
+tl051,TL051CP,typ_gbp,3.0 MHz
+tl051,TL051CP,typ_gbp,3.1 MHz
+tl051,TL051CP,typ_supply_current,2.6 mA
+tl051,TL051CP,typ_supply_current,2.7 mA
+tl051,TL051CP,min_op_supply_volt,±5 V
+tl051,TL051CP,max_op_supply_volt,±15 V
+tl051,TL051CP,min_op_temp,0
+tl051,TL051CP,max_op_temp,70
+tl051,TL051CPE4,part_family,N
+tl051,TL051CPE4,typ_gbp,3.0 MHz
+tl051,TL051CPE4,typ_gbp,3.1 MHz
+tl051,TL051CPE4,typ_supply_current,2.6 mA
+tl051,TL051CPE4,typ_supply_current,2.7 mA
+tl051,TL051CPE4,min_op_supply_volt,±5 V
+tl051,TL051CPE4,max_op_supply_volt,±15 V
+tl051,TL051CPE4,min_op_temp,0
+tl051,TL051CPE4,max_op_temp,70
+tl051,TL051ID,part_family,N
+tl051,TL051ID,typ_gbp,3.0 MHz
+tl051,TL051ID,typ_gbp,3.1 MHz
+tl051,TL051ID,typ_supply_current,2.6 mA
+tl051,TL051ID,typ_supply_current,2.7 mA
+tl051,TL051ID,min_op_supply_volt,±5 V
+tl051,TL051ID,max_op_supply_volt,±15 V
+tl051,TL051ID,min_op_temp,-40
+tl051,TL051ID,max_op_temp,85
+tl051,TL051IDR,part_family,N
+tl051,TL051IDR,typ_gbp,3.0 MHz
+tl051,TL051IDR,typ_gbp,3.1 MHz
+tl051,TL051IDR,typ_supply_current,2.6 mA
+tl051,TL051IDR,typ_supply_current,2.7 mA
+tl051,TL051IDR,min_op_supply_volt,±5 V
+tl051,TL051IDR,max_op_supply_volt,±15 V
+tl051,TL051IDR,min_op_temp,-40
+tl051,TL051IDR,max_op_temp,85
+tl051,TL051IP,part_family,N
+tl051,TL051IP,typ_gbp,3.0 MHz
+tl051,TL051IP,typ_gbp,3.1 MHz
+tl051,TL051IP,typ_supply_current,2.6 mA
+tl051,TL051IP,typ_supply_current,2.7 mA
+tl051,TL051IP,min_op_supply_volt,±5 V
+tl051,TL051IP,max_op_supply_volt,±15 V
+tl051,TL051IP,min_op_temp,0
+tl051,TL051IP,max_op_temp,70
+tl051,TL052ACD,part_family,N
+tl051,TL052ACD,typ_gbp,3.0 MHz
+tl051,TL052ACD,typ_supply_current,4.6 mA
+tl051,TL052ACD,typ_supply_current,4.8 mA
+tl051,TL052ACD,min_op_supply_volt,±5 V
+tl051,TL052ACD,max_op_supply_volt,±15 V
+tl051,TL052ACD,min_op_temp,0
+tl051,TL052ACD,max_op_temp,70
+tl051,TL052ACDG4,part_family,N
+tl051,TL052ACDG4,typ_gbp,3.0 MHz
+tl051,TL052ACDG4,typ_supply_current,4.6 mA
+tl051,TL052ACDG4,typ_supply_current,4.8 mA
+tl051,TL052ACDG4,min_op_supply_volt,±5 V
+tl051,TL052ACDG4,max_op_supply_volt,±15 V
+tl051,TL052ACDG4,min_op_temp,0
+tl051,TL052ACDG4,max_op_temp,70
+tl051,TL052ACDR,part_family,N
+tl051,TL052ACDR,typ_gbp,3.0 MHz
+tl051,TL052ACDR,typ_supply_current,4.6 mA
+tl051,TL052ACDR,typ_supply_current,4.8 mA
+tl051,TL052ACDR,min_op_supply_volt,±5 V
+tl051,TL052ACDR,max_op_supply_volt,±15 V
+tl051,TL052ACDR,min_op_temp,0
+tl051,TL052ACDR,max_op_temp,70
+tl051,TL052ACDRG4,part_family,N
+tl051,TL052ACDRG4,typ_gbp,3.0 MHz
+tl051,TL052ACDRG4,typ_supply_current,4.6 mA
+tl051,TL052ACDRG4,typ_supply_current,4.8 mA
+tl051,TL052ACDRG4,min_op_supply_volt,±5 V
+tl051,TL052ACDRG4,max_op_supply_volt,±15 V
+tl051,TL052ACDRG4,min_op_temp,0
+tl051,TL052ACDRG4,max_op_temp,70
+tl051,TL052ACP,part_family,N
+tl051,TL052ACP,typ_gbp,3.0 MHz
+tl051,TL052ACP,typ_supply_current,4.6 mA
+tl051,TL052ACP,typ_supply_current,4.8 mA
+tl051,TL052ACP,min_op_supply_volt,±5 V
+tl051,TL052ACP,max_op_supply_volt,±15 V
+tl051,TL052ACP,min_op_temp,0
+tl051,TL052ACP,max_op_temp,70
+tl051,TL052ACPE4,part_family,N
+tl051,TL052ACPE4,typ_gbp,3.0 MHz
+tl051,TL052ACPE4,typ_supply_current,4.6 mA
+tl051,TL052ACPE4,typ_supply_current,4.8 mA
+tl051,TL052ACPE4,min_op_supply_volt,±5 V
+tl051,TL052ACPE4,max_op_supply_volt,±15 V
+tl051,TL052ACPE4,min_op_temp,0
+tl051,TL052ACPE4,max_op_temp,70
+tl051,TL052AID,part_family,N
+tl051,TL052AID,typ_gbp,3.0 MHz
+tl051,TL052AID,typ_supply_current,4.6 mA
+tl051,TL052AID,typ_supply_current,4.8 mA
+tl051,TL052AID,min_op_supply_volt,±5 V
+tl051,TL052AID,max_op_supply_volt,±15 V
+tl051,TL052AID,min_op_temp,-40
+tl051,TL052AID,max_op_temp,85
+tl051,TL052AIDE4,part_family,N
+tl051,TL052AIDE4,typ_gbp,3.0 MHz
+tl051,TL052AIDE4,typ_supply_current,4.6 mA
+tl051,TL052AIDE4,typ_supply_current,4.8 mA
+tl051,TL052AIDE4,min_op_supply_volt,±5 V
+tl051,TL052AIDE4,max_op_supply_volt,±15 V
+tl051,TL052AIDE4,min_op_temp,-40
+tl051,TL052AIDE4,max_op_temp,85
+tl051,TL052AIDG4,part_family,N
+tl051,TL052AIDG4,typ_gbp,3.0 MHz
+tl051,TL052AIDG4,typ_supply_current,4.6 mA
+tl051,TL052AIDG4,typ_supply_current,4.8 mA
+tl051,TL052AIDG4,min_op_supply_volt,±5 V
+tl051,TL052AIDG4,max_op_supply_volt,±15 V
+tl051,TL052AIDG4,min_op_temp,-40
+tl051,TL052AIDG4,max_op_temp,85
+tl051,TL052AIDR,part_family,N
+tl051,TL052AIDR,typ_gbp,3.0 MHz
+tl051,TL052AIDR,typ_supply_current,4.6 mA
+tl051,TL052AIDR,typ_supply_current,4.8 mA
+tl051,TL052AIDR,min_op_supply_volt,±5 V
+tl051,TL052AIDR,max_op_supply_volt,±15 V
+tl051,TL052AIDR,min_op_temp,-40
+tl051,TL052AIDR,max_op_temp,85
+tl051,TL052AIP,part_family,N
+tl051,TL052AIP,typ_gbp,3.0 MHz
+tl051,TL052AIP,typ_supply_current,4.6 mA
+tl051,TL052AIP,typ_supply_current,4.8 mA
+tl051,TL052AIP,min_op_supply_volt,±5 V
+tl051,TL052AIP,max_op_supply_volt,±15 V
+tl051,TL052AIP,min_op_temp,0
+tl051,TL052AIP,max_op_temp,70
+tl051,TL052AMFKB,part_family,N
+tl051,TL052AMFKB,typ_gbp,3.0 MHz
+tl051,TL052AMFKB,typ_supply_current,4.6 mA
+tl051,TL052AMFKB,typ_supply_current,4.8 mA
+tl051,TL052AMFKB,min_op_supply_volt,±5 V
+tl051,TL052AMFKB,max_op_supply_volt,±15 V
+tl051,TL052AMFKB,min_op_temp,-55
+tl051,TL052AMFKB,max_op_temp,125
+tl051,TL052AMJGB,part_family,N
+tl051,TL052AMJGB,typ_gbp,3.0 MHz
+tl051,TL052AMJGB,typ_supply_current,4.6 mA
+tl051,TL052AMJGB,typ_supply_current,4.8 mA
+tl051,TL052AMJGB,min_op_supply_volt,±5 V
+tl051,TL052AMJGB,max_op_supply_volt,±15 V
+tl051,TL052AMJGB,min_op_temp,-55
+tl051,TL052AMJGB,max_op_temp,125
+tl051,TL052CD,part_family,N
+tl051,TL052CD,typ_gbp,3.0 MHz
+tl051,TL052CD,typ_supply_current,4.6 mA
+tl051,TL052CD,typ_supply_current,4.8 mA
+tl051,TL052CD,min_op_supply_volt,±5 V
+tl051,TL052CD,max_op_supply_volt,±15 V
+tl051,TL052CD,min_op_temp,0
+tl051,TL052CD,max_op_temp,70
+tl051,TL052CDG4,part_family,N
+tl051,TL052CDG4,typ_gbp,3.0 MHz
+tl051,TL052CDG4,typ_supply_current,4.6 mA
+tl051,TL052CDG4,typ_supply_current,4.8 mA
+tl051,TL052CDG4,min_op_supply_volt,±5 V
+tl051,TL052CDG4,max_op_supply_volt,±15 V
+tl051,TL052CDG4,min_op_temp,0
+tl051,TL052CDG4,max_op_temp,70
+tl051,TL052CDR,part_family,N
+tl051,TL052CDR,typ_gbp,3.0 MHz
+tl051,TL052CDR,typ_supply_current,4.6 mA
+tl051,TL052CDR,typ_supply_current,4.8 mA
+tl051,TL052CDR,min_op_supply_volt,±5 V
+tl051,TL052CDR,max_op_supply_volt,±15 V
+tl051,TL052CDR,min_op_temp,0
+tl051,TL052CDR,max_op_temp,70
+tl051,TL052CDRE4,part_family,N
+tl051,TL052CDRE4,typ_gbp,3.0 MHz
+tl051,TL052CDRE4,typ_supply_current,4.6 mA
+tl051,TL052CDRE4,typ_supply_current,4.8 mA
+tl051,TL052CDRE4,min_op_supply_volt,±5 V
+tl051,TL052CDRE4,max_op_supply_volt,±15 V
+tl051,TL052CDRE4,min_op_temp,0
+tl051,TL052CDRE4,max_op_temp,70
+tl051,TL052CDRG4,part_family,N
+tl051,TL052CDRG4,typ_gbp,3.0 MHz
+tl051,TL052CDRG4,typ_supply_current,4.6 mA
+tl051,TL052CDRG4,typ_supply_current,4.8 mA
+tl051,TL052CDRG4,min_op_supply_volt,±5 V
+tl051,TL052CDRG4,max_op_supply_volt,±15 V
+tl051,TL052CDRG4,min_op_temp,0
+tl051,TL052CDRG4,max_op_temp,70
+tl051,TL052CP,part_family,N
+tl051,TL052CP,typ_gbp,3.0 MHz
+tl051,TL052CP,typ_supply_current,4.6 mA
+tl051,TL052CP,typ_supply_current,4.8 mA
+tl051,TL052CP,min_op_supply_volt,±5 V
+tl051,TL052CP,max_op_supply_volt,±15 V
+tl051,TL052CP,min_op_temp,0
+tl051,TL052CP,max_op_temp,70
+tl051,TL052CPSR,part_family,N
+tl051,TL052CPSR,typ_gbp,3.0 MHz
+tl051,TL052CPSR,typ_supply_current,4.6 mA
+tl051,TL052CPSR,typ_supply_current,4.8 mA
+tl051,TL052CPSR,min_op_supply_volt,±5 V
+tl051,TL052CPSR,max_op_supply_volt,±15 V
+tl051,TL052CPSR,min_op_temp,0
+tl051,TL052CPSR,max_op_temp,70
+tl051,TL052ID,part_family,N
+tl051,TL052ID,typ_gbp,3.0 MHz
+tl051,TL052ID,typ_supply_current,4.6 mA
+tl051,TL052ID,typ_supply_current,4.8 mA
+tl051,TL052ID,min_op_supply_volt,±5 V
+tl051,TL052ID,max_op_supply_volt,±15 V
+tl051,TL052ID,min_op_temp,-40
+tl051,TL052ID,max_op_temp,85
+tl051,TL052IDG4,part_family,N
+tl051,TL052IDG4,typ_gbp,3.0 MHz
+tl051,TL052IDG4,typ_supply_current,4.6 mA
+tl051,TL052IDG4,typ_supply_current,4.8 mA
+tl051,TL052IDG4,min_op_supply_volt,±5 V
+tl051,TL052IDG4,max_op_supply_volt,±15 V
+tl051,TL052IDG4,min_op_temp,-40
+tl051,TL052IDG4,max_op_temp,85
+tl051,TL052IDR,part_family,N
+tl051,TL052IDR,typ_gbp,3.0 MHz
+tl051,TL052IDR,typ_supply_current,4.6 mA
+tl051,TL052IDR,typ_supply_current,4.8 mA
+tl051,TL052IDR,min_op_supply_volt,±5 V
+tl051,TL052IDR,max_op_supply_volt,±15 V
+tl051,TL052IDR,min_op_temp,-40
+tl051,TL052IDR,max_op_temp,85
+tl051,TL052IDRE4,part_family,N
+tl051,TL052IDRE4,typ_gbp,3.0 MHz
+tl051,TL052IDRE4,typ_supply_current,4.6 mA
+tl051,TL052IDRE4,typ_supply_current,4.8 mA
+tl051,TL052IDRE4,min_op_supply_volt,±5 V
+tl051,TL052IDRE4,max_op_supply_volt,±15 V
+tl051,TL052IDRE4,min_op_temp,-40
+tl051,TL052IDRE4,max_op_temp,85
+tl051,TL052IP,part_family,N
+tl051,TL052IP,typ_gbp,3.0 MHz
+tl051,TL052IP,typ_supply_current,4.6 mA
+tl051,TL052IP,typ_supply_current,4.8 mA
+tl051,TL052IP,min_op_supply_volt,±5 V
+tl051,TL052IP,max_op_supply_volt,±15 V
+tl051,TL052IP,min_op_temp,-40
+tl051,TL052IP,max_op_temp,85
+tl051,TL052IPE4,part_family,N
+tl051,TL052IPE4,typ_gbp,3.0 MHz
+tl051,TL052IPE4,typ_supply_current,4.6 mA
+tl051,TL052IPE4,typ_supply_current,4.8 mA
+tl051,TL052IPE4,min_op_supply_volt,±5 V
+tl051,TL052IPE4,max_op_supply_volt,±15 V
+tl051,TL052IPE4,min_op_temp,-40
+tl051,TL052IPE4,max_op_temp,85
+tl051,TL052MFKB,part_family,N
+tl051,TL052MFKB,typ_gbp,3.0 MHz
+tl051,TL052MFKB,typ_supply_current,4.6 mA
+tl051,TL052MFKB,typ_supply_current,4.8 mA
+tl051,TL052MFKB,min_op_supply_volt,±5 V
+tl051,TL052MFKB,max_op_supply_volt,±15 V
+tl051,TL052MFKB,min_op_temp,-55
+tl051,TL052MFKB,max_op_temp,125
+tl051,TL052MJG,part_family,N
+tl051,TL052MJG,typ_gbp,3.0 MHz
+tl051,TL052MJG,typ_supply_current,4.6 mA
+tl051,TL052MJG,typ_supply_current,4.8 mA
+tl051,TL052MJG,min_op_supply_volt,±5 V
+tl051,TL052MJG,max_op_supply_volt,±15 V
+tl051,TL052MJG,min_op_temp,-55
+tl051,TL052MJG,max_op_temp,125
+tl051,TL052MJGB,part_family,N
+tl051,TL052MJGB,typ_gbp,3.0 MHz
+tl051,TL052MJGB,typ_supply_current,4.6 mA
+tl051,TL052MJGB,typ_supply_current,4.8 mA
+tl051,TL052MJGB,min_op_supply_volt,±5 V
+tl051,TL052MJGB,max_op_supply_volt,±15 V
+tl051,TL052MJGB,min_op_temp,-55
+tl051,TL052MJGB,max_op_temp,125
+tl051,TL054ACD,part_family,N
+tl051,TL054ACD,typ_gbp,2.7 MHz
+tl051,TL054ACD,typ_supply_current,8.1 mA
+tl051,TL054ACD,typ_supply_current,8.4 mA
+tl051,TL054ACD,min_op_supply_volt,±5 V
+tl051,TL054ACD,max_op_supply_volt,±15 V
+tl051,TL054ACD,min_op_temp,0
+tl051,TL054ACD,max_op_temp,70
+tl051,TL054ACDE4,part_family,N
+tl051,TL054ACDE4,typ_gbp,2.7 MHz
+tl051,TL054ACDE4,typ_supply_current,8.1 mA
+tl051,TL054ACDE4,typ_supply_current,8.4 mA
+tl051,TL054ACDE4,min_op_supply_volt,±5 V
+tl051,TL054ACDE4,max_op_supply_volt,±15 V
+tl051,TL054ACDE4,min_op_temp,0
+tl051,TL054ACDE4,max_op_temp,70
+tl051,TL054ACDG4,part_family,N
+tl051,TL054ACDG4,typ_gbp,2.7 MHz
+tl051,TL054ACDG4,typ_supply_current,8.1 mA
+tl051,TL054ACDG4,typ_supply_current,8.4 mA
+tl051,TL054ACDG4,min_op_supply_volt,±5 V
+tl051,TL054ACDG4,max_op_supply_volt,±15 V
+tl051,TL054ACDG4,min_op_temp,0
+tl051,TL054ACDG4,max_op_temp,70
+tl051,TL054ACDR,part_family,N
+tl051,TL054ACDR,typ_gbp,2.7 MHz
+tl051,TL054ACDR,typ_supply_current,8.1 mA
+tl051,TL054ACDR,typ_supply_current,8.4 mA
+tl051,TL054ACDR,min_op_supply_volt,±5 V
+tl051,TL054ACDR,max_op_supply_volt,±15 V
+tl051,TL054ACDR,min_op_temp,0
+tl051,TL054ACDR,max_op_temp,70
+tl051,TL054ACN,part_family,N
+tl051,TL054ACN,typ_gbp,2.7 MHz
+tl051,TL054ACN,typ_supply_current,8.1 mA
+tl051,TL054ACN,typ_supply_current,8.4 mA
+tl051,TL054ACN,min_op_supply_volt,±5 V
+tl051,TL054ACN,max_op_supply_volt,±15 V
+tl051,TL054ACN,min_op_temp,0
+tl051,TL054ACN,max_op_temp,70
+tl051,TL054AID,part_family,N
+tl051,TL054AID,typ_gbp,2.7 MHz
+tl051,TL054AID,typ_supply_current,8.1 mA
+tl051,TL054AID,typ_supply_current,8.4 mA
+tl051,TL054AID,min_op_supply_volt,±5 V
+tl051,TL054AID,max_op_supply_volt,±15 V
+tl051,TL054AID,min_op_temp,-40
+tl051,TL054AID,max_op_temp,85
+tl051,TL054AIDG4,part_family,N
+tl051,TL054AIDG4,typ_gbp,2.7 MHz
+tl051,TL054AIDG4,typ_supply_current,8.1 mA
+tl051,TL054AIDG4,typ_supply_current,8.4 mA
+tl051,TL054AIDG4,min_op_supply_volt,±5 V
+tl051,TL054AIDG4,max_op_supply_volt,±15 V
+tl051,TL054AIDG4,min_op_temp,-40
+tl051,TL054AIDG4,max_op_temp,85
+tl051,TL054AIDR,part_family,N
+tl051,TL054AIDR,typ_gbp,2.7 MHz
+tl051,TL054AIDR,typ_supply_current,8.1 mA
+tl051,TL054AIDR,typ_supply_current,8.4 mA
+tl051,TL054AIDR,min_op_supply_volt,±5 V
+tl051,TL054AIDR,max_op_supply_volt,±15 V
+tl051,TL054AIDR,min_op_temp,-40
+tl051,TL054AIDR,max_op_temp,85
+tl051,TL054AIDRE4,part_family,N
+tl051,TL054AIDRE4,typ_gbp,2.7 MHz
+tl051,TL054AIDRE4,typ_supply_current,8.1 mA
+tl051,TL054AIDRE4,typ_supply_current,8.4 mA
+tl051,TL054AIDRE4,min_op_supply_volt,±5 V
+tl051,TL054AIDRE4,max_op_supply_volt,±15 V
+tl051,TL054AIDRE4,min_op_temp,-40
+tl051,TL054AIDRE4,max_op_temp,85
+tl051,TL054AIN,part_family,N
+tl051,TL054AIN,typ_gbp,2.7 MHz
+tl051,TL054AIN,typ_supply_current,8.1 mA
+tl051,TL054AIN,typ_supply_current,8.4 mA
+tl051,TL054AIN,min_op_supply_volt,±5 V
+tl051,TL054AIN,max_op_supply_volt,±15 V
+tl051,TL054AIN,min_op_temp,-40
+tl051,TL054AIN,max_op_temp,85
+tl051,TL054AMFKB,part_family,N
+tl051,TL054AMFKB,typ_gbp,2.7 MHz
+tl051,TL054AMFKB,typ_supply_current,8.1 mA
+tl051,TL054AMFKB,typ_supply_current,8.4 mA
+tl051,TL054AMFKB,min_op_supply_volt,±5 V
+tl051,TL054AMFKB,max_op_supply_volt,±15 V
+tl051,TL054AMFKB,min_op_temp,-55
+tl051,TL054AMFKB,max_op_temp,125
+tl051,TL054AMJB,part_family,N
+tl051,TL054AMJB,typ_gbp,2.7 MHz
+tl051,TL054AMJB,typ_supply_current,8.1 mA
+tl051,TL054AMJB,typ_supply_current,8.4 mA
+tl051,TL054AMJB,min_op_supply_volt,±5 V
+tl051,TL054AMJB,max_op_supply_volt,±15 V
+tl051,TL054AMJB,min_op_temp,-55
+tl051,TL054AMJB,max_op_temp,125
+tl051,TL054CD,part_family,N
+tl051,TL054CD,typ_gbp,2.7 MHz
+tl051,TL054CD,typ_supply_current,8.1 mA
+tl051,TL054CD,typ_supply_current,8.4 mA
+tl051,TL054CD,min_op_supply_volt,±5 V
+tl051,TL054CD,max_op_supply_volt,±15 V
+tl051,TL054CD,min_op_temp,0
+tl051,TL054CD,max_op_temp,70
+tl051,TL054CDBR,part_family,N
+tl051,TL054CDBR,typ_gbp,2.7 MHz
+tl051,TL054CDBR,typ_supply_current,8.1 mA
+tl051,TL054CDBR,typ_supply_current,8.4 mA
+tl051,TL054CDBR,min_op_supply_volt,±5 V
+tl051,TL054CDBR,max_op_supply_volt,±15 V
+tl051,TL054CDBR,min_op_temp,0
+tl051,TL054CDBR,max_op_temp,70
+tl051,TL054CDE4,part_family,N
+tl051,TL054CDE4,typ_gbp,2.7 MHz
+tl051,TL054CDE4,typ_supply_current,8.1 mA
+tl051,TL054CDE4,typ_supply_current,8.4 mA
+tl051,TL054CDE4,min_op_supply_volt,±5 V
+tl051,TL054CDE4,max_op_supply_volt,±15 V
+tl051,TL054CDE4,min_op_temp,0
+tl051,TL054CDE4,max_op_temp,70
+tl051,TL054CDR,part_family,N
+tl051,TL054CDR,typ_gbp,2.7 MHz
+tl051,TL054CDR,typ_supply_current,8.1 mA
+tl051,TL054CDR,typ_supply_current,8.4 mA
+tl051,TL054CDR,min_op_supply_volt,±5 V
+tl051,TL054CDR,max_op_supply_volt,±15 V
+tl051,TL054CDR,min_op_temp,0
+tl051,TL054CDR,max_op_temp,70
+tl051,TL054CDRG4,part_family,N
+tl051,TL054CDRG4,typ_gbp,2.7 MHz
+tl051,TL054CDRG4,typ_supply_current,8.1 mA
+tl051,TL054CDRG4,typ_supply_current,8.4 mA
+tl051,TL054CDRG4,min_op_supply_volt,±5 V
+tl051,TL054CDRG4,max_op_supply_volt,±15 V
+tl051,TL054CDRG4,min_op_temp,0
+tl051,TL054CDRG4,max_op_temp,70
+tl051,TL054CN,part_family,N
+tl051,TL054CN,typ_gbp,2.7 MHz
+tl051,TL054CN,typ_supply_current,8.1 mA
+tl051,TL054CN,typ_supply_current,8.4 mA
+tl051,TL054CN,min_op_supply_volt,±5 V
+tl051,TL054CN,max_op_supply_volt,±15 V
+tl051,TL054CN,min_op_temp,0
+tl051,TL054CN,max_op_temp,70
+tl051,TL054CNE4,part_family,N
+tl051,TL054CNE4,typ_gbp,2.7 MHz
+tl051,TL054CNE4,typ_supply_current,8.1 mA
+tl051,TL054CNE4,typ_supply_current,8.4 mA
+tl051,TL054CNE4,min_op_supply_volt,±5 V
+tl051,TL054CNE4,max_op_supply_volt,±15 V
+tl051,TL054CNE4,min_op_temp,0
+tl051,TL054CNE4,max_op_temp,70
+tl051,TL054CNSR,part_family,N
+tl051,TL054CNSR,typ_gbp,2.7 MHz
+tl051,TL054CNSR,typ_supply_current,8.1 mA
+tl051,TL054CNSR,typ_supply_current,8.4 mA
+tl051,TL054CNSR,min_op_supply_volt,±5 V
+tl051,TL054CNSR,max_op_supply_volt,±15 V
+tl051,TL054CNSR,min_op_temp,0
+tl051,TL054CNSR,max_op_temp,70
+tl051,TL054ID,part_family,N
+tl051,TL054ID,typ_gbp,2.7 MHz
+tl051,TL054ID,typ_supply_current,8.1 mA
+tl051,TL054ID,typ_supply_current,8.4 mA
+tl051,TL054ID,min_op_supply_volt,±5 V
+tl051,TL054ID,max_op_supply_volt,±15 V
+tl051,TL054ID,min_op_temp,-40
+tl051,TL054ID,max_op_temp,85
+tl051,TL054IDE4,part_family,N
+tl051,TL054IDE4,typ_gbp,2.7 MHz
+tl051,TL054IDE4,typ_supply_current,8.1 mA
+tl051,TL054IDE4,typ_supply_current,8.4 mA
+tl051,TL054IDE4,min_op_supply_volt,±5 V
+tl051,TL054IDE4,max_op_supply_volt,±15 V
+tl051,TL054IDE4,min_op_temp,-40
+tl051,TL054IDE4,max_op_temp,85
+tl051,TL054IDG4,part_family,N
+tl051,TL054IDG4,typ_gbp,2.7 MHz
+tl051,TL054IDG4,typ_supply_current,8.1 mA
+tl051,TL054IDG4,typ_supply_current,8.4 mA
+tl051,TL054IDG4,min_op_supply_volt,±5 V
+tl051,TL054IDG4,max_op_supply_volt,±15 V
+tl051,TL054IDG4,min_op_temp,-40
+tl051,TL054IDG4,max_op_temp,85
+tl051,TL054IDR,part_family,N
+tl051,TL054IDR,typ_gbp,2.7 MHz
+tl051,TL054IDR,typ_supply_current,8.1 mA
+tl051,TL054IDR,typ_supply_current,8.4 mA
+tl051,TL054IDR,min_op_supply_volt,±5 V
+tl051,TL054IDR,max_op_supply_volt,±15 V
+tl051,TL054IDR,min_op_temp,-40
+tl051,TL054IDR,max_op_temp,85
+tl051,TL054IDRG4,part_family,N
+tl051,TL054IDRG4,typ_gbp,2.7 MHz
+tl051,TL054IDRG4,typ_supply_current,8.1 mA
+tl051,TL054IDRG4,typ_supply_current,8.4 mA
+tl051,TL054IDRG4,min_op_supply_volt,±5 V
+tl051,TL054IDRG4,max_op_supply_volt,±15 V
+tl051,TL054IDRG4,min_op_temp,-40
+tl051,TL054IDRG4,max_op_temp,85
+tl051,TL054IN,part_family,N
+tl051,TL054IN,typ_gbp,2.7 MHz
+tl051,TL054IN,typ_supply_current,8.1 mA
+tl051,TL054IN,typ_supply_current,8.4 mA
+tl051,TL054IN,min_op_supply_volt,±5 V
+tl051,TL054IN,max_op_supply_volt,±15 V
+tl051,TL054IN,min_op_temp,-40
+tl051,TL054IN,max_op_temp,85
+tl051,TL054INMJB,part_family,N
+tl051,TL054INMJB,typ_gbp,2.7 MHz
+tl051,TL054INMJB,typ_supply_current,8.1 mA
+tl051,TL054INMJB,typ_supply_current,8.4 mA
+tl051,TL054INMJB,min_op_supply_volt,±5 V
+tl051,TL054INMJB,max_op_supply_volt,±15 V
+tl051,TL054INMJB,min_op_temp,-55
+tl051,TL054INMJB,max_op_temp,125
+tl051,TL054MFKB,part_family,N
+tl051,TL054MFKB,typ_gbp,2.7 MHz
+tl051,TL054MFKB,typ_supply_current,8.1 mA
+tl051,TL054MFKB,typ_supply_current,8.4 mA
+tl051,TL054MFKB,min_op_supply_volt,±5 V
+tl051,TL054MFKB,max_op_supply_volt,±15 V
+tl051,TL054MFKB,min_op_temp,-55
+tl051,TL054MFKB,max_op_temp,125
+tl051,TL054MJ,part_family,N
+tl051,TL054MJ,typ_gbp,2.7 MHz
+tl051,TL054MJ,typ_supply_current,8.1 mA
+tl051,TL054MJ,typ_supply_current,8.4 mA
+tl051,TL054MJ,min_op_supply_volt,±5 V
+tl051,TL054MJ,max_op_supply_volt,±15 V
+tl051,TL054MJ,min_op_temp,-55
+tl051,TL054MJ,max_op_temp,125
+tl051,TL05X,part_family,Y
+tl051,TL05X,min_op_supply_volt,±5 V
+tl051,TL05X,max_op_supply_volt,±15 V
+tl051,TL05XA,part_family,Y
+tl051,TL05XA,min_op_supply_volt,±5 V
+tl051,TL05XA,max_op_supply_volt,±15 V
+tle2021-q1,TLE202X-Q1,part_family,Y
+tle2021-q1,TLE202X-Q1,min_op_supply_volt,±2 V
+tle2021-q1,TLE202X-Q1,max_op_supply_volt,±20 V
+tle2021-q1,TLE202X-Q1,min_op_temp,-40
+tle2021-q1,TLE202X-Q1,max_op_temp,125
+tle2021-q1,TLE202XA-Q1,part_family,Y
+tle2021-q1,TLE202XA-Q1,min_op_supply_volt,±2 V
+tle2021-q1,TLE202XA-Q1,max_op_supply_volt,±20 V
+tle2021-q1,TLE202XA-Q1,min_op_temp,-40
+tle2021-q1,TLE202XA-Q1,max_op_temp,125
+tle2021-q1,TLE2021AQDRG4Q1,part_family,N
+tle2021-q1,TLE2021AQDRG4Q1,typ_gbp,1.2 MHz
+tle2021-q1,TLE2021AQDRG4Q1,typ_gbp,2.0 MHz
+tle2021-q1,TLE2021AQDRG4Q1,typ_supply_current,170.0 uA
+tle2021-q1,TLE2021AQDRG4Q1,typ_supply_current,200.0 uA
+tle2021-q1,TLE2021AQDRG4Q1,min_op_supply_volt,±2 V
+tle2021-q1,TLE2021AQDRG4Q1,max_op_supply_volt,±20 V
+tle2021-q1,TLE2021AQDRG4Q1,min_op_temp,-40
+tle2021-q1,TLE2021AQDRG4Q1,max_op_temp,125
+tle2021-q1,TLE2021AQDRQ1,part_family,N
+tle2021-q1,TLE2021AQDRQ1,typ_gbp,1.2 MHz
+tle2021-q1,TLE2021AQDRQ1,typ_gbp,2.0 MHz
+tle2021-q1,TLE2021AQDRQ1,typ_supply_current,170.0 uA
+tle2021-q1,TLE2021AQDRQ1,typ_supply_current,200.0 uA
+tle2021-q1,TLE2021AQDRQ1,min_op_supply_volt,±2 V
+tle2021-q1,TLE2021AQDRQ1,max_op_supply_volt,±20 V
+tle2021-q1,TLE2021AQDRQ1,min_op_temp,-40
+tle2021-q1,TLE2021AQDRQ1,max_op_temp,125
+tle2021-q1,TLE2021AQPWRQ1,part_family,N
+tle2021-q1,TLE2021AQPWRQ1,typ_gbp,1.2 MHz
+tle2021-q1,TLE2021AQPWRQ1,typ_gbp,2.0 MHz
+tle2021-q1,TLE2021AQPWRQ1,typ_supply_current,170.0 uA
+tle2021-q1,TLE2021AQPWRQ1,typ_supply_current,200.0 uA
+tle2021-q1,TLE2021AQPWRQ1,min_op_supply_volt,±2 V
+tle2021-q1,TLE2021AQPWRQ1,max_op_supply_volt,±20 V
+tle2021-q1,TLE2021AQPWRQ1,min_op_temp,-40
+tle2021-q1,TLE2021AQPWRQ1,max_op_temp,125
+tle2021-q1,TLE2021QDRG4Q1,part_family,N
+tle2021-q1,TLE2021QDRG4Q1,typ_gbp,1.2 MHz
+tle2021-q1,TLE2021QDRG4Q1,typ_gbp,2.0 MHz
+tle2021-q1,TLE2021QDRG4Q1,typ_supply_current,170.0 uA
+tle2021-q1,TLE2021QDRG4Q1,typ_supply_current,200.0 uA
+tle2021-q1,TLE2021QDRG4Q1,min_op_supply_volt,±2 V
+tle2021-q1,TLE2021QDRG4Q1,max_op_supply_volt,±20 V
+tle2021-q1,TLE2021QDRG4Q1,min_op_temp,-40
+tle2021-q1,TLE2021QDRG4Q1,max_op_temp,125
+tle2021-q1,TLE2021QDRQ1,part_family,N
+tle2021-q1,TLE2021QDRQ1,typ_gbp,1.2 MHz
+tle2021-q1,TLE2021QDRQ1,typ_gbp,2.0 MHz
+tle2021-q1,TLE2021QDRQ1,typ_supply_current,170.0 uA
+tle2021-q1,TLE2021QDRQ1,typ_supply_current,200.0 uA
+tle2021-q1,TLE2021QDRQ1,min_op_supply_volt,±2 V
+tle2021-q1,TLE2021QDRQ1,max_op_supply_volt,±20 V
+tle2021-q1,TLE2021QDRQ1,min_op_temp,-40
+tle2021-q1,TLE2021QDRQ1,max_op_temp,125
+tle2021-q1,TLE2021QPWRQ,part_family,N
+tle2021-q1,TLE2021QPWRQ,typ_gbp,1.2 MHz
+tle2021-q1,TLE2021QPWRQ,typ_gbp,2.0 MHz
+tle2021-q1,TLE2021QPWRQ,typ_supply_current,170.0 uA
+tle2021-q1,TLE2021QPWRQ,typ_supply_current,200.0 uA
+tle2021-q1,TLE2021QPWRQ,min_op_supply_volt,±2 V
+tle2021-q1,TLE2021QPWRQ,max_op_supply_volt,±20 V
+tle2021-q1,TLE2021QPWRQ,min_op_temp,-40
+tle2021-q1,TLE2021QPWRQ,max_op_temp,125
+tle2021-q1,TLE2022AQDRG4Q1,part_family,N
+tle2021-q1,TLE2022AQDRG4Q1,typ_gbp,1.7 MHz
+tle2021-q1,TLE2022AQDRG4Q1,typ_gbp,2.8 MHz
+tle2021-q1,TLE2022AQDRG4Q1,typ_supply_current,450.0 uA
+tle2021-q1,TLE2022AQDRG4Q1,typ_supply_current,550.0 uA
+tle2021-q1,TLE2022AQDRG4Q1,min_op_supply_volt,±2 V
+tle2021-q1,TLE2022AQDRG4Q1,max_op_supply_volt,±20 V
+tle2021-q1,TLE2022AQDRG4Q1,min_op_temp,-40
+tle2021-q1,TLE2022AQDRG4Q1,max_op_temp,125
+tle2021-q1,TLE2022AQDRQ1,part_family,N
+tle2021-q1,TLE2022AQDRQ1,typ_gbp,1.7 MHz
+tle2021-q1,TLE2022AQDRQ1,typ_gbp,2.8 MHz
+tle2021-q1,TLE2022AQDRQ1,typ_supply_current,450.0 uA
+tle2021-q1,TLE2022AQDRQ1,typ_supply_current,550.0 uA
+tle2021-q1,TLE2022AQDRQ1,min_op_supply_volt,±2 V
+tle2021-q1,TLE2022AQDRQ1,max_op_supply_volt,±20 V
+tle2021-q1,TLE2022AQDRQ1,min_op_temp,-40
+tle2021-q1,TLE2022AQDRQ1,max_op_temp,125
+tle2021-q1,TLE2022AQPWRQ1,part_family,N
+tle2021-q1,TLE2022AQPWRQ1,typ_gbp,1.7 MHz
+tle2021-q1,TLE2022AQPWRQ1,typ_gbp,2.8 MHz
+tle2021-q1,TLE2022AQPWRQ1,typ_supply_current,450.0 uA
+tle2021-q1,TLE2022AQPWRQ1,typ_supply_current,550.0 uA
+tle2021-q1,TLE2022AQPWRQ1,min_op_supply_volt,±2 V
+tle2021-q1,TLE2022AQPWRQ1,max_op_supply_volt,±20 V
+tle2021-q1,TLE2022AQPWRQ1,min_op_temp,-40
+tle2021-q1,TLE2022AQPWRQ1,max_op_temp,125
+tle2021-q1,TLE2022QDRG4Q1,part_family,N
+tle2021-q1,TLE2022QDRG4Q1,typ_gbp,1.7 MHz
+tle2021-q1,TLE2022QDRG4Q1,typ_gbp,2.8 MHz
+tle2021-q1,TLE2022QDRG4Q1,typ_supply_current,450.0 uA
+tle2021-q1,TLE2022QDRG4Q1,typ_supply_current,550.0 uA
+tle2021-q1,TLE2022QDRG4Q1,min_op_supply_volt,±2 V
+tle2021-q1,TLE2022QDRG4Q1,max_op_supply_volt,±20 V
+tle2021-q1,TLE2022QDRG4Q1,min_op_temp,-40
+tle2021-q1,TLE2022QDRG4Q1,max_op_temp,125
+tle2021-q1,TLE2022QDRQ1,part_family,N
+tle2021-q1,TLE2022QDRQ1,typ_gbp,1.7 MHz
+tle2021-q1,TLE2022QDRQ1,typ_gbp,2.8 MHz
+tle2021-q1,TLE2022QDRQ1,typ_supply_current,450.0 uA
+tle2021-q1,TLE2022QDRQ1,typ_supply_current,550.0 uA
+tle2021-q1,TLE2022QDRQ1,min_op_supply_volt,±2 V
+tle2021-q1,TLE2022QDRQ1,max_op_supply_volt,±20 V
+tle2021-q1,TLE2022QDRQ1,min_op_temp,-40
+tle2021-q1,TLE2022QDRQ1,max_op_temp,125
+tle2021-q1,TLE2022QPWRQ1,part_family,N
+tle2021-q1,TLE2022QPWRQ1,typ_gbp,1.7 MHz
+tle2021-q1,TLE2022QPWRQ1,typ_gbp,2.8 MHz
+tle2021-q1,TLE2022QPWRQ1,typ_supply_current,450.0 uA
+tle2021-q1,TLE2022QPWRQ1,typ_supply_current,550.0 uA
+tle2021-q1,TLE2022QPWRQ1,min_op_supply_volt,±2 V
+tle2021-q1,TLE2022QPWRQ1,max_op_supply_volt,±20 V
+tle2021-q1,TLE2022QPWRQ1,min_op_temp,-40
+tle2021-q1,TLE2022QPWRQ1,max_op_temp,125
+tle2021-q1,TLE2024AQDWRG4Q1,part_family,N
+tle2021-q1,TLE2024AQDWRG4Q1,typ_gbp,1.7 MHz
+tle2021-q1,TLE2024AQDWRG4Q1,typ_gbp,2.8 MHz
+tle2021-q1,TLE2024AQDWRG4Q1,typ_supply_current,800.0 uA
+tle2021-q1,TLE2024AQDWRG4Q1,typ_supply_current,1050.0 uA
+tle2021-q1,TLE2024AQDWRG4Q1,min_op_supply_volt,±2 V
+tle2021-q1,TLE2024AQDWRG4Q1,max_op_supply_volt,±20 V
+tle2021-q1,TLE2024AQDWRG4Q1,min_op_temp,-40
+tle2021-q1,TLE2024AQDWRG4Q1,max_op_temp,125
+tle2021-q1,TLE2024AQDWRQ1,part_family,N
+tle2021-q1,TLE2024AQDWRQ1,typ_gbp,1.7 MHz
+tle2021-q1,TLE2024AQDWRQ1,typ_gbp,2.8 MHz
+tle2021-q1,TLE2024AQDWRQ1,typ_supply_current,800.0 uA
+tle2021-q1,TLE2024AQDWRQ1,typ_supply_current,1050.0 uA
+tle2021-q1,TLE2024AQDWRQ1,min_op_supply_volt,±2 V
+tle2021-q1,TLE2024AQDWRQ1,max_op_supply_volt,±20 V
+tle2021-q1,TLE2024AQDWRQ1,min_op_temp,-40
+tle2021-q1,TLE2024AQDWRQ1,max_op_temp,125
+tle2021-q1,TLE2024QDWRG4Q1,part_family,N
+tle2021-q1,TLE2024QDWRG4Q1,typ_gbp,1.7 MHz
+tle2021-q1,TLE2024QDWRG4Q1,typ_gbp,2.8 MHz
+tle2021-q1,TLE2024QDWRG4Q1,typ_supply_current,800.0 uA
+tle2021-q1,TLE2024QDWRG4Q1,typ_supply_current,1050.0 uA
+tle2021-q1,TLE2024QDWRG4Q1,min_op_supply_volt,±2 V
+tle2021-q1,TLE2024QDWRG4Q1,max_op_supply_volt,±20 V
+tle2021-q1,TLE2024QDWRG4Q1,min_op_temp,-40
+tle2021-q1,TLE2024QDWRG4Q1,max_op_temp,125
+tle2021-q1,TLE2024QDWRQQ1,part_family,N
+tle2021-q1,TLE2024QDWRQQ1,typ_gbp,1.7 MHz
+tle2021-q1,TLE2024QDWRQQ1,typ_gbp,2.8 MHz
+tle2021-q1,TLE2024QDWRQQ1,typ_supply_current,800.0 uA
+tle2021-q1,TLE2024QDWRQQ1,typ_supply_current,1050.0 uA
+tle2021-q1,TLE2024QDWRQQ1,min_op_supply_volt,±2 V
+tle2021-q1,TLE2024QDWRQQ1,max_op_supply_volt,±20 V
+tle2021-q1,TLE2024QDWRQQ1,min_op_temp,-40
+tle2021-q1,TLE2024QDWRQQ1,max_op_temp,125
+tlv2322,TLV2322,part_family,Y
+tlv2322,TLV2322,typ_gbp,27.0 kHz
+tlv2322,TLV2322,typ_gbp,85.0 kHz
+tlv2322,TLV2322,typ_supply_current,12.0 uA
+tlv2322,TLV2322,typ_supply_current,20.0 uA
+tlv2322,TLV2322,min_op_supply_volt,2 V
+tlv2322,TLV2322,max_op_supply_volt,8 V
+tlv2322,TLV2322,min_op_temp,-40
+tlv2322,TLV2322,max_op_temp,85
+tlv2322,TLV2322Y,part_family,Y
+tlv2322,TLV2322Y,typ_gbp,27.0 kHz
+tlv2322,TLV2322Y,typ_gbp,85.0 kHz
+tlv2322,TLV2322Y,typ_supply_current,12.0 uA
+tlv2322,TLV2322Y,typ_supply_current,20.0 uA
+tlv2322,TLV2322Y,min_op_supply_volt,2 V
+tlv2322,TLV2322Y,max_op_supply_volt,8 V
+tlv2322,TLV2322Y,min_op_temp,-40
+tlv2322,TLV2322Y,max_op_temp,85
+tlv2322,TLV2324,part_family,Y
+tlv2322,TLV2324,typ_gbp,27.0 kHz
+tlv2322,TLV2324,typ_gbp,85.0 kHz
+tlv2322,TLV2324,typ_supply_current,24.0 uA
+tlv2322,TLV2324,typ_supply_current,39.0 uA
+tlv2322,TLV2324,min_op_supply_volt,2 V
+tlv2322,TLV2324,max_op_supply_volt,8 V
+tlv2322,TLV2324,min_op_temp,-40
+tlv2322,TLV2324,max_op_temp,85
+tlv2322,TLV2324Y,part_family,Y
+tlv2322,TLV2324Y,typ_gbp,27.0 kHz
+tlv2322,TLV2324Y,typ_gbp,85.0 kHz
+tlv2322,TLV2324Y,typ_supply_current,24.0 uA
+tlv2322,TLV2324Y,typ_supply_current,39.0 uA
+tlv2322,TLV2324Y,min_op_supply_volt,2 V
+tlv2322,TLV2324Y,max_op_supply_volt,8 V
+tlv2322,TLV2324Y,min_op_temp,-40
+tlv2322,TLV2324Y,max_op_temp,85
+tlv2322,TLV2322ID,part_family,N
+tlv2322,TLV2322ID,typ_gbp,27.0 kHz
+tlv2322,TLV2322ID,typ_gbp,85.0 kHz
+tlv2322,TLV2322ID,typ_supply_current,12.0 uA
+tlv2322,TLV2322ID,typ_supply_current,20.0 uA
+tlv2322,TLV2322ID,min_op_supply_volt,2 V
+tlv2322,TLV2322ID,max_op_supply_volt,8 V
+tlv2322,TLV2322ID,min_op_temp,-40
+tlv2322,TLV2322ID,max_op_temp,85
+tlv2322,TLV2322IDR,part_family,N
+tlv2322,TLV2322IDR,typ_gbp,27.0 kHz
+tlv2322,TLV2322IDR,typ_gbp,85.0 kHz
+tlv2322,TLV2322IDR,typ_supply_current,12.0 uA
+tlv2322,TLV2322IDR,typ_supply_current,20.0 uA
+tlv2322,TLV2322IDR,min_op_supply_volt,2 V
+tlv2322,TLV2322IDR,max_op_supply_volt,8 V
+tlv2322,TLV2322IDR,min_op_temp,-40
+tlv2322,TLV2322IDR,max_op_temp,85
+tlv2322,TLV232IDRG4,part_family,N
+tlv2322,TLV232IDRG4,typ_gbp,27.0 kHz
+tlv2322,TLV232IDRG4,typ_gbp,85.0 kHz
+tlv2322,TLV232IDRG4,typ_supply_current,12.0 uA
+tlv2322,TLV232IDRG4,typ_supply_current,20.0 uA
+tlv2322,TLV232IDRG4,min_op_supply_volt,2 V
+tlv2322,TLV232IDRG4,max_op_supply_volt,8 V
+tlv2322,TLV232IDRG4,min_op_temp,-40
+tlv2322,TLV232IDRG4,max_op_temp,85
+tlv2322,TLV2322IP,part_family,N
+tlv2322,TLV2322IP,typ_gbp,27.0 kHz
+tlv2322,TLV2322IP,typ_gbp,85.0 kHz
+tlv2322,TLV2322IP,typ_supply_current,12.0 uA
+tlv2322,TLV2322IP,typ_supply_current,20.0 uA
+tlv2322,TLV2322IP,min_op_supply_volt,2 V
+tlv2322,TLV2322IP,max_op_supply_volt,8 V
+tlv2322,TLV2322IP,min_op_temp,-40
+tlv2322,TLV2322IP,max_op_temp,85
+tlv2322,TLV2322IPW,part_family,N
+tlv2322,TLV2322IPW,typ_gbp,27.0 kHz
+tlv2322,TLV2322IPW,typ_gbp,85.0 kHz
+tlv2322,TLV2322IPW,typ_supply_current,12.0 uA
+tlv2322,TLV2322IPW,typ_supply_current,20.0 uA
+tlv2322,TLV2322IPW,min_op_supply_volt,2 V
+tlv2322,TLV2322IPW,max_op_supply_volt,8 V
+tlv2322,TLV2322IPW,min_op_temp,-40
+tlv2322,TLV2322IPW,max_op_temp,85
+tlv2322,TLV2322IPWLE,part_family,N
+tlv2322,TLV2322IPWLE,typ_gbp,27.0 kHz
+tlv2322,TLV2322IPWLE,typ_gbp,85.0 kHz
+tlv2322,TLV2322IPWLE,typ_supply_current,12.0 uA
+tlv2322,TLV2322IPWLE,typ_supply_current,20.0 uA
+tlv2322,TLV2322IPWLE,min_op_supply_volt,2 V
+tlv2322,TLV2322IPWLE,max_op_supply_volt,8 V
+tlv2322,TLV2322IPWLE,min_op_temp,-40
+tlv2322,TLV2322IPWLE,max_op_temp,85
+tlv2322,TLV2322IPWR,part_family,N
+tlv2322,TLV2322IPWR,typ_gbp,27.0 kHz
+tlv2322,TLV2322IPWR,typ_gbp,85.0 kHz
+tlv2322,TLV2322IPWR,typ_supply_current,12.0 uA
+tlv2322,TLV2322IPWR,typ_supply_current,20.0 uA
+tlv2322,TLV2322IPWR,min_op_supply_volt,2 V
+tlv2322,TLV2322IPWR,max_op_supply_volt,8 V
+tlv2322,TLV2322IPWR,min_op_temp,-40
+tlv2322,TLV2322IPWR,max_op_temp,85
+tlv2322,TLV2324ID,part_family,N
+tlv2322,TLV2324ID,typ_gbp,27.0 kHz
+tlv2322,TLV2324ID,typ_gbp,85.0 kHz
+tlv2322,TLV2324ID,typ_supply_current,24.0 uA
+tlv2322,TLV2324ID,typ_supply_current,39.0 uA
+tlv2322,TLV2324ID,min_op_supply_volt,2 V
+tlv2322,TLV2324ID,max_op_supply_volt,8 V
+tlv2322,TLV2324ID,min_op_temp,-40
+tlv2322,TLV2324ID,max_op_temp,85
+tlv2322,TLV2324IDG4,part_family,N
+tlv2322,TLV2324IDG4,typ_gbp,27.0 kHz
+tlv2322,TLV2324IDG4,typ_gbp,85.0 kHz
+tlv2322,TLV2324IDG4,typ_supply_current,24.0 uA
+tlv2322,TLV2324IDG4,typ_supply_current,39.0 uA
+tlv2322,TLV2324IDG4,min_op_supply_volt,2 V
+tlv2322,TLV2324IDG4,max_op_supply_volt,8 V
+tlv2322,TLV2324IDG4,min_op_temp,-40
+tlv2322,TLV2324IDG4,max_op_temp,85
+tlv2322,TLV2324IDR,part_family,N
+tlv2322,TLV2324IDR,typ_gbp,27.0 kHz
+tlv2322,TLV2324IDR,typ_gbp,85.0 kHz
+tlv2322,TLV2324IDR,typ_supply_current,24.0 uA
+tlv2322,TLV2324IDR,typ_supply_current,39.0 uA
+tlv2322,TLV2324IDR,min_op_supply_volt,2 V
+tlv2322,TLV2324IDR,max_op_supply_volt,8 V
+tlv2322,TLV2324IDR,min_op_temp,-40
+tlv2322,TLV2324IDR,max_op_temp,85
+tlv2322,TLV2324IN,part_family,N
+tlv2322,TLV2324IN,typ_gbp,27.0 kHz
+tlv2322,TLV2324IN,typ_gbp,85.0 kHz
+tlv2322,TLV2324IN,typ_supply_current,24.0 uA
+tlv2322,TLV2324IN,typ_supply_current,39.0 uA
+tlv2322,TLV2324IN,min_op_supply_volt,2 V
+tlv2322,TLV2324IN,max_op_supply_volt,8 V
+tlv2322,TLV2324IN,min_op_temp,-40
+tlv2322,TLV2324IN,max_op_temp,85
+tlv2322,TLV2324IPW,part_family,N
+tlv2322,TLV2324IPW,typ_gbp,27.0 kHz
+tlv2322,TLV2324IPW,typ_gbp,85.0 kHz
+tlv2322,TLV2324IPW,typ_supply_current,24.0 uA
+tlv2322,TLV2324IPW,typ_supply_current,39.0 uA
+tlv2322,TLV2324IPW,min_op_supply_volt,2 V
+tlv2322,TLV2324IPW,max_op_supply_volt,8 V
+tlv2322,TLV2324IPW,min_op_temp,-40
+tlv2322,TLV2324IPW,max_op_temp,85
+tlv2322,TLV2324IPWLE,part_family,N
+tlv2322,TLV2324IPWLE,typ_gbp,27.0 kHz
+tlv2322,TLV2324IPWLE,typ_gbp,85.0 kHz
+tlv2322,TLV2324IPWLE,typ_supply_current,24.0 uA
+tlv2322,TLV2324IPWLE,typ_supply_current,39.0 uA
+tlv2322,TLV2324IPWLE,min_op_supply_volt,2 V
+tlv2322,TLV2324IPWLE,max_op_supply_volt,8 V
+tlv2322,TLV2324IPWLE,min_op_temp,-40
+tlv2322,TLV2324IPWLE,max_op_temp,85
+tlv2322,TLV2324IPWR,part_family,N
+tlv2322,TLV2324IPWR,typ_gbp,27.0 kHz
+tlv2322,TLV2324IPWR,typ_gbp,85.0 kHz
+tlv2322,TLV2324IPWR,typ_supply_current,24.0 uA
+tlv2322,TLV2324IPWR,typ_supply_current,39.0 uA
+tlv2322,TLV2324IPWR,min_op_supply_volt,2 V
+tlv2322,TLV2324IPWR,max_op_supply_volt,8 V
+tlv2322,TLV2324IPWR,min_op_temp,-40
+tlv2322,TLV2324IPWR,max_op_temp,85
+tlv2322,TLV2324Y,part_family,N
+tlv2322,TLV2322Y,part_family,N

--- a/opamps/data/test/test_gold.csv
+++ b/opamps/data/test/test_gold.csv
@@ -1,0 +1,1309 @@
+1360fa,LT1360,part_family,Y
+1360fa,LT1360,typ_gbp,50.0 MHz
+1360fa,LT1360,typ_gbp,37.0 MHz
+1360fa,LT1360,typ_gbp,32.0 MHz
+1360fa,LT1360,typ_supply_current,4.0 mA
+1360fa,LT1360,typ_supply_current,3.8 mA
+1360fa,LT1360,min_op_supply_volt,±2.5 V
+1360fa,LT1360,max_op_supply_volt,±15 V
+1360fa,LT1360,min_op_temp,-40
+1360fa,LT1360,max_op_temp,85
+1360fa,LT1360CN8,part_family,N
+1360fa,LT1360CN8,typ_gbp,50.0 MHz
+1360fa,LT1360CN8,typ_gbp,37.0 MHz
+1360fa,LT1360CN8,typ_gbp,32.0 MHz
+1360fa,LT1360CN8,typ_supply_current,4.0 mA
+1360fa,LT1360CN8,typ_supply_current,3.8 mA
+1360fa,LT1360CN8,min_op_supply_volt,±2.5 V
+1360fa,LT1360CN8,max_op_supply_volt,±15 V
+1360fa,LT1360CN8,min_op_temp,-40
+1360fa,LT1360CN8,max_op_temp,85
+1360fa,LT1360CS8,part_family,N
+1360fa,LT1360CS8,typ_gbp,50.0 MHz
+1360fa,LT1360CS8,typ_gbp,37.0 MHz
+1360fa,LT1360CS8,typ_gbp,32.0 MHz
+1360fa,LT1360CS8,typ_supply_current,4.0 mA
+1360fa,LT1360CS8,typ_supply_current,3.8 mA
+1360fa,LT1360CS8,min_op_supply_volt,±2.5 V
+1360fa,LT1360CS8,max_op_supply_volt,±15 V
+1360fa,LT1360CS8,min_op_temp,-40
+1360fa,LT1360CS8,max_op_temp,85
+1366fb,LT1366,part_family,Y
+1366fb,LT1366,typ_gbp,0.4 MHz
+1366fb,LT1366,typ_supply_current,340.0 uA
+1366fb,LT1366,typ_supply_current,385.0 uA
+1366fb,LT1366,typ_supply_current,330.0 uA
+1366fb,LT1366,typ_supply_current,375.0 uA
+1366fb,LT1366,typ_supply_current,370.0 uA
+1366fb,LT1366,typ_supply_current,415.0 uA
+1366fb,LT1366,min_op_supply_volt,1.8 V
+1366fb,LT1366,max_op_supply_volt,36 V
+1366fb,LT1366,min_op_temp,0
+1366fb,LT1366,max_op_temp,70
+1366fb,LT1366CN8#PBF,part_family,N
+1366fb,LT1366CN8#PBF,typ_gbp,0.4 MHz
+1366fb,LT1366CN8#PBF,typ_supply_current,340.0 uA
+1366fb,LT1366CN8#PBF,typ_supply_current,385.0 uA
+1366fb,LT1366CN8#PBF,typ_supply_current,330.0 uA
+1366fb,LT1366CN8#PBF,typ_supply_current,375.0 uA
+1366fb,LT1366CN8#PBF,typ_supply_current,370.0 uA
+1366fb,LT1366CN8#PBF,typ_supply_current,415.0 uA
+1366fb,LT1366CN8#PBF,min_op_supply_volt,1.8 V
+1366fb,LT1366CN8#PBF,max_op_supply_volt,36 V
+1366fb,LT1366CN8#PBF,min_op_temp,0
+1366fb,LT1366CN8#PBF,max_op_temp,70
+1366fb,LT1366CN8#TRPBF,part_family,N
+1366fb,LT1366CN8#TRPBF,typ_gbp,0.4 MHz
+1366fb,LT1366CN8#TRPBF,typ_supply_current,340.0 uA
+1366fb,LT1366CN8#TRPBF,typ_supply_current,385.0 uA
+1366fb,LT1366CN8#TRPBF,typ_supply_current,330.0 uA
+1366fb,LT1366CN8#TRPBF,typ_supply_current,375.0 uA
+1366fb,LT1366CN8#TRPBF,typ_supply_current,370.0 uA
+1366fb,LT1366CN8#TRPBF,typ_supply_current,415.0 uA
+1366fb,LT1366CN8#TRPBF,min_op_supply_volt,1.8 V
+1366fb,LT1366CN8#TRPBF,max_op_supply_volt,36 V
+1366fb,LT1366CN8#TRPBF,min_op_temp,0
+1366fb,LT1366CN8#TRPBF,max_op_temp,70
+1366fb,LT1366CS8#PBF,part_family,N
+1366fb,LT1366CS8#PBF,typ_gbp,0.4 MHz
+1366fb,LT1366CS8#PBF,typ_supply_current,340.0 uA
+1366fb,LT1366CS8#PBF,typ_supply_current,385.0 uA
+1366fb,LT1366CS8#PBF,typ_supply_current,330.0 uA
+1366fb,LT1366CS8#PBF,typ_supply_current,375.0 uA
+1366fb,LT1366CS8#PBF,typ_supply_current,370.0 uA
+1366fb,LT1366CS8#PBF,typ_supply_current,415.0 uA
+1366fb,LT1366CS8#PBF,min_op_supply_volt,1.8 V
+1366fb,LT1366CS8#PBF,max_op_supply_volt,36 V
+1366fb,LT1366CS8#PBF,min_op_temp,0
+1366fb,LT1366CS8#PBF,max_op_temp,70
+1366fb,LT1366CS8#TRPBF,part_family,N
+1366fb,LT1366CS8#TRPBF,typ_gbp,0.4 MHz
+1366fb,LT1366CS8#TRPBF,typ_supply_current,340.0 uA
+1366fb,LT1366CS8#TRPBF,typ_supply_current,385.0 uA
+1366fb,LT1366CS8#TRPBF,typ_supply_current,330.0 uA
+1366fb,LT1366CS8#TRPBF,typ_supply_current,375.0 uA
+1366fb,LT1366CS8#TRPBF,typ_supply_current,370.0 uA
+1366fb,LT1366CS8#TRPBF,typ_supply_current,415.0 uA
+1366fb,LT1366CS8#TRPBF,min_op_supply_volt,1.8 V
+1366fb,LT1366CS8#TRPBF,max_op_supply_volt,36 V
+1366fb,LT1366CS8#TRPBF,min_op_temp,0
+1366fb,LT1366CS8#TRPBF,max_op_temp,70
+1366fb,LT1367,part_family,Y
+1366fb,LT1367,typ_gbp,0.4 MHz
+1366fb,LT1367,typ_supply_current,340.0 uA
+1366fb,LT1367,typ_supply_current,385.0 uA
+1366fb,LT1367,typ_supply_current,330.0 uA
+1366fb,LT1367,typ_supply_current,375.0 uA
+1366fb,LT1367,typ_supply_current,370.0 uA
+1366fb,LT1367,typ_supply_current,415.0 uA
+1366fb,LT1367,min_op_supply_volt,1.8 V
+1366fb,LT1367,max_op_supply_volt,36 V
+1366fb,LT1367,min_op_temp,0
+1366fb,LT1367,max_op_temp,70
+1366fb,LT1367CS#PBF,part_family,N
+1366fb,LT1367CS#PBF,typ_gbp,0.4 MHz
+1366fb,LT1367CS#PBF,typ_supply_current,340.0 uA
+1366fb,LT1367CS#PBF,typ_supply_current,385.0 uA
+1366fb,LT1367CS#PBF,typ_supply_current,330.0 uA
+1366fb,LT1367CS#PBF,typ_supply_current,375.0 uA
+1366fb,LT1367CS#PBF,typ_supply_current,370.0 uA
+1366fb,LT1367CS#PBF,typ_supply_current,415.0 uA
+1366fb,LT1367CS#PBF,min_op_supply_volt,1.8 V
+1366fb,LT1367CS#PBF,max_op_supply_volt,36 V
+1366fb,LT1367CS#PBF,min_op_temp,0
+1366fb,LT1367CS#PBF,max_op_temp,70
+1366fb,LT1367CS#TRPBF,part_family,N
+1366fb,LT1367CS#TRPBF,typ_gbp,0.4 MHz
+1366fb,LT1367CS#TRPBF,typ_supply_current,340.0 uA
+1366fb,LT1367CS#TRPBF,typ_supply_current,385.0 uA
+1366fb,LT1367CS#TRPBF,typ_supply_current,330.0 uA
+1366fb,LT1367CS#TRPBF,typ_supply_current,375.0 uA
+1366fb,LT1367CS#TRPBF,typ_supply_current,370.0 uA
+1366fb,LT1367CS#TRPBF,typ_supply_current,415.0 uA
+1366fb,LT1367CS#TRPBF,min_op_supply_volt,1.8 V
+1366fb,LT1367CS#TRPBF,max_op_supply_volt,36 V
+1366fb,LT1367CS#TRPBF,min_op_temp,0
+1366fb,LT1367CS#TRPBF,max_op_temp,70
+1366fb,LT1368,part_family,Y
+1366fb,LT1368,typ_gbp,0.16 MHz
+1366fb,LT1368,typ_supply_current,340.0 uA
+1366fb,LT1368,typ_supply_current,385.0 uA
+1366fb,LT1368,typ_supply_current,330.0 uA
+1366fb,LT1368,typ_supply_current,375.0 uA
+1366fb,LT1368,typ_supply_current,370.0 uA
+1366fb,LT1368,typ_supply_current,415.0 uA
+1366fb,LT1368,min_op_supply_volt,1.8 V
+1366fb,LT1368,max_op_supply_volt,36 V
+1366fb,LT1368,min_op_temp,0
+1366fb,LT1368,max_op_temp,70
+1366fb,LT1368CN8#PBF,part_family,N
+1366fb,LT1368CN8#PBF,typ_gbp,0.16 MHz
+1366fb,LT1368CN8#PBF,typ_supply_current,340.0 uA
+1366fb,LT1368CN8#PBF,typ_supply_current,385.0 uA
+1366fb,LT1368CN8#PBF,typ_supply_current,330.0 uA
+1366fb,LT1368CN8#PBF,typ_supply_current,375.0 uA
+1366fb,LT1368CN8#PBF,typ_supply_current,370.0 uA
+1366fb,LT1368CN8#PBF,typ_supply_current,415.0 uA
+1366fb,LT1368CN8#PBF,min_op_supply_volt,1.8 V
+1366fb,LT1368CN8#PBF,max_op_supply_volt,36 V
+1366fb,LT1368CN8#PBF,min_op_temp,0
+1366fb,LT1368CN8#PBF,max_op_temp,70
+1366fb,LT1368CN8#TRPBF,part_family,N
+1366fb,LT1368CN8#TRPBF,typ_gbp,0.16 MHz
+1366fb,LT1368CN8#TRPBF,typ_supply_current,340.0 uA
+1366fb,LT1368CN8#TRPBF,typ_supply_current,385.0 uA
+1366fb,LT1368CN8#TRPBF,typ_supply_current,330.0 uA
+1366fb,LT1368CN8#TRPBF,typ_supply_current,375.0 uA
+1366fb,LT1368CN8#TRPBF,typ_supply_current,370.0 uA
+1366fb,LT1368CN8#TRPBF,typ_supply_current,415.0 uA
+1366fb,LT1368CN8#TRPBF,min_op_supply_volt,1.8 V
+1366fb,LT1368CN8#TRPBF,max_op_supply_volt,36 V
+1366fb,LT1368CN8#TRPBF,min_op_temp,0
+1366fb,LT1368CN8#TRPBF,max_op_temp,70
+1366fb,LT1368CS8#PBF,part_family,N
+1366fb,LT1368CS8#PBF,typ_gbp,0.16 MHz
+1366fb,LT1368CS8#PBF,typ_supply_current,340.0 uA
+1366fb,LT1368CS8#PBF,typ_supply_current,385.0 uA
+1366fb,LT1368CS8#PBF,typ_supply_current,330.0 uA
+1366fb,LT1368CS8#PBF,typ_supply_current,375.0 uA
+1366fb,LT1368CS8#PBF,typ_supply_current,370.0 uA
+1366fb,LT1368CS8#PBF,typ_supply_current,415.0 uA
+1366fb,LT1368CS8#PBF,min_op_supply_volt,1.8 V
+1366fb,LT1368CS8#PBF,max_op_supply_volt,36 V
+1366fb,LT1368CS8#PBF,min_op_temp,0
+1366fb,LT1368CS8#PBF,max_op_temp,70
+1366fb,LT1368CS8#TRPBF,part_family,N
+1366fb,LT1368CS8#TRPBF,typ_gbp,0.16 MHz
+1366fb,LT1368CS8#TRPBF,typ_supply_current,340.0 uA
+1366fb,LT1368CS8#TRPBF,typ_supply_current,385.0 uA
+1366fb,LT1368CS8#TRPBF,typ_supply_current,330.0 uA
+1366fb,LT1368CS8#TRPBF,typ_supply_current,375.0 uA
+1366fb,LT1368CS8#TRPBF,typ_supply_current,370.0 uA
+1366fb,LT1368CS8#TRPBF,typ_supply_current,415.0 uA
+1366fb,LT1368CS8#TRPBF,min_op_supply_volt,1.8 V
+1366fb,LT1368CS8#TRPBF,max_op_supply_volt,36 V
+1366fb,LT1368CS8#TRPBF,min_op_temp,0
+1366fb,LT1368CS8#TRPBF,max_op_temp,70
+1366fb,LT1369,part_family,Y
+1366fb,LT1369,typ_gbp,0.16 MHz
+1366fb,LT1369,typ_supply_current,340.0 uA
+1366fb,LT1369,typ_supply_current,385.0 uA
+1366fb,LT1369,typ_supply_current,330.0 uA
+1366fb,LT1369,typ_supply_current,375.0 uA
+1366fb,LT1369,typ_supply_current,370.0 uA
+1366fb,LT1369,typ_supply_current,415.0 uA
+1366fb,LT1369,min_op_supply_volt,1.8 V
+1366fb,LT1369,max_op_supply_volt,36 V
+1366fb,LT1369,min_op_temp,0
+1366fb,LT1369,max_op_temp,70
+1366fb,LT1369CS#PBF,part_family,N
+1366fb,LT1369CS#PBF,typ_gbp,0.16 MHz
+1366fb,LT1369CS#PBF,typ_supply_current,340.0 uA
+1366fb,LT1369CS#PBF,typ_supply_current,385.0 uA
+1366fb,LT1369CS#PBF,typ_supply_current,330.0 uA
+1366fb,LT1369CS#PBF,typ_supply_current,375.0 uA
+1366fb,LT1369CS#PBF,typ_supply_current,370.0 uA
+1366fb,LT1369CS#PBF,typ_supply_current,415.0 uA
+1366fb,LT1369CS#PBF,min_op_supply_volt,1.8 V
+1366fb,LT1369CS#PBF,max_op_supply_volt,36 V
+1366fb,LT1369CS#PBF,min_op_temp,0
+1366fb,LT1369CS#PBF,max_op_temp,70
+1366fb,LT1369CS#TRPBF,part_family,N
+1366fb,LT1369CS#TRPBF,typ_gbp,0.16 MHz
+1366fb,LT1369CS#TRPBF,typ_supply_current,340.0 uA
+1366fb,LT1369CS#TRPBF,typ_supply_current,385.0 uA
+1366fb,LT1369CS#TRPBF,typ_supply_current,330.0 uA
+1366fb,LT1369CS#TRPBF,typ_supply_current,375.0 uA
+1366fb,LT1369CS#TRPBF,typ_supply_current,370.0 uA
+1366fb,LT1369CS#TRPBF,typ_supply_current,415.0 uA
+1366fb,LT1369CS#TRPBF,min_op_supply_volt,1.8 V
+1366fb,LT1369CS#TRPBF,max_op_supply_volt,36 V
+1366fb,LT1369CS#TRPBF,min_op_temp,0
+1366fb,LT1369CS#TRPBF,max_op_temp,70
+13989fa,LT1398,part_family,Y
+13989fa,LT1398,typ_supply_current,4.6 mA
+13989fa,LT1398,min_op_supply_volt,4 V
+13989fa,LT1398,max_op_supply_volt,±6 V
+13989fa,LT1398,min_op_temp,-40
+13989fa,LT1398,max_op_temp,85
+13989fa,LT1398CS,part_family,N
+13989fa,LT1398CS,typ_supply_current,4.6 mA
+13989fa,LT1398CS,min_op_supply_volt,4 V
+13989fa,LT1398CS,max_op_supply_volt,±6 V
+13989fa,LT1398CS,min_op_temp,-40
+13989fa,LT1398CS,max_op_temp,85
+13989fa,LT1399,part_family,Y
+13989fa,LT1399,typ_supply_current,4.6 mA
+13989fa,LT1399,min_op_supply_volt,4 V
+13989fa,LT1399,max_op_supply_volt,±6 V
+13989fa,LT1399,min_op_temp,-40
+13989fa,LT1399,max_op_temp,85
+13989fa,LT1399CGN,part_family,N
+13989fa,LT1399CGN,typ_supply_current,4.6 mA
+13989fa,LT1399CGN,min_op_supply_volt,4 V
+13989fa,LT1399CGN,max_op_supply_volt,±6 V
+13989fa,LT1399CGN,min_op_temp,-40
+13989fa,LT1399CGN,max_op_temp,85
+13989fa,LT1399CS,part_family,N
+13989fa,LT1399CS,typ_supply_current,4.6 mA
+13989fa,LT1399CS,min_op_supply_volt,4 V
+13989fa,LT1399CS,max_op_supply_volt,±6 V
+13989fa,LT1399CS,min_op_temp,-40
+13989fa,LT1399CS,max_op_temp,85
+13989fa,LT1399HVCS,part_family,N
+13989fa,LT1399HVCS,typ_supply_current,4.6 mA
+13989fa,LT1399HVCS,min_op_supply_volt,4 V
+13989fa,LT1399HVCS,max_op_supply_volt,±7.5 V
+13989fa,LT1399HVCS,min_op_temp,-40
+13989fa,LT1399HVCS,max_op_temp,85
+13989fa,LT1399IGN,part_family,N
+13989fa,LT1399IGN,typ_supply_current,4.6 mA
+13989fa,LT1399IGN,min_op_supply_volt,4 V
+13989fa,LT1399IGN,max_op_supply_volt,±6 V
+13989fa,LT1399IGN,min_op_temp,-40
+13989fa,LT1399IGN,max_op_temp,85
+13989fa,LT1399IS,part_family,N
+13989fa,LT1399IS,typ_supply_current,4.6 mA
+13989fa,LT1399IS,min_op_supply_volt,4 V
+13989fa,LT1399IS,max_op_supply_volt,±6 V
+13989fa,LT1399IS,min_op_temp,-40
+13989fa,LT1399IS,max_op_temp,85
+20512fd,LTC2051,part_family,Y
+20512fd,LTC2051,typ_gbp,3.0 MHz
+20512fd,LTC2051,typ_supply_current,0.75 mA
+20512fd,LTC2051,typ_supply_current,0.85 mA
+20512fd,LTC2051CDD,part_family,N
+20512fd,LTC2051CDD,typ_gbp,3.0 MHz
+20512fd,LTC2051CDD,typ_supply_current,0.75 mA
+20512fd,LTC2051CDD,typ_supply_current,0.85 mA
+20512fd,LTC2051CDD,min_op_supply_volt,3 V
+20512fd,LTC2051CDD,max_op_supply_volt,5 V
+20512fd,LTC2051CDD,min_op_temp,0
+20512fd,LTC2051CDD,max_op_temp,70
+20512fd,LTC2051CS8,part_family,N
+20512fd,LTC2051CS8,typ_gbp,3.0 MHz
+20512fd,LTC2051CS8,typ_supply_current,0.75 mA
+20512fd,LTC2051CS8,typ_supply_current,0.85 mA
+20512fd,LTC2051CS8,min_op_supply_volt,3 V
+20512fd,LTC2051CS8,max_op_supply_volt,5 V
+20512fd,LTC2051CS8,min_op_temp,0
+20512fd,LTC2051CS8,max_op_temp,70
+20512fd,LTC2051CMS8,part_family,N
+20512fd,LTC2051CMS8,typ_gbp,3.0 MHz
+20512fd,LTC2051CMS8,typ_supply_current,0.75 mA
+20512fd,LTC2051CMS8,typ_supply_current,0.85 mA
+20512fd,LTC2051CMS8,min_op_supply_volt,3 V
+20512fd,LTC2051CMS8,max_op_supply_volt,5 V
+20512fd,LTC2051CMS8,min_op_temp,0
+20512fd,LTC2051CMS8,max_op_temp,70
+20512fd,LTC2051CMS10,part_family,N
+20512fd,LTC2051CMS10,typ_gbp,3.0 MHz
+20512fd,LTC2051CMS10,typ_supply_current,0.75 mA
+20512fd,LTC2051CMS10,typ_supply_current,0.85 mA
+20512fd,LTC2051CMS10,min_op_supply_volt,3 V
+20512fd,LTC2051CMS10,max_op_supply_volt,5 V
+20512fd,LTC2051CMS10,min_op_temp,0
+20512fd,LTC2051CMS10,max_op_temp,70
+20512fd,LTC2051HVCDD,part_family,N
+20512fd,LTC2051HVCDD,typ_gbp,3.0 MHz
+20512fd,LTC2051HVCDD,typ_supply_current,0.75 mA
+20512fd,LTC2051HVCDD,typ_supply_current,0.85 mA
+20512fd,LTC2051HVCDD,min_op_supply_volt,3 V
+20512fd,LTC2051HVCDD,max_op_supply_volt,5 V
+20512fd,LTC2051HVCDD,max_op_supply_volt,±5 V
+20512fd,LTC2051HVCDD,min_op_temp,0
+20512fd,LTC2051HVCDD,max_op_temp,70
+20512fd,LTC2051HVCS8,part_family,N
+20512fd,LTC2051HVCS8,typ_gbp,3.0 MHz
+20512fd,LTC2051HVCS8,typ_supply_current,0.75 mA
+20512fd,LTC2051HVCS8,typ_supply_current,0.85 mA
+20512fd,LTC2051HVCS8,min_op_supply_volt,3 V
+20512fd,LTC2051HVCS8,max_op_supply_volt,5 V
+20512fd,LTC2051HVCS8,max_op_supply_volt,±5 V
+20512fd,LTC2051HVCS8,min_op_temp,0
+20512fd,LTC2051HVCS8,max_op_temp,70
+20512fd,LTC2051HVCMS8,part_family,N
+20512fd,LTC2051HVCMS8,typ_gbp,3.0 MHz
+20512fd,LTC2051HVCMS8,typ_supply_current,0.75 mA
+20512fd,LTC2051HVCMS8,typ_supply_current,0.85 mA
+20512fd,LTC2051HVCMS8,min_op_supply_volt,3 V
+20512fd,LTC2051HVCMS8,max_op_supply_volt,5 V
+20512fd,LTC2051HVCMS8,max_op_supply_volt,±5 V
+20512fd,LTC2051HVCMS8,min_op_temp,0
+20512fd,LTC2051HVCMS8,max_op_temp,70
+20512fd,LTC2051HVCMS10,part_family,N
+20512fd,LTC2051HVCMS10,typ_gbp,3.0 MHz
+20512fd,LTC2051HVCMS10,typ_supply_current,0.75 mA
+20512fd,LTC2051HVCMS10,typ_supply_current,0.85 mA
+20512fd,LTC2051HVCMS10,min_op_supply_volt,3 V
+20512fd,LTC2051HVCMS10,max_op_supply_volt,5 V
+20512fd,LTC2051HVCMS10,max_op_supply_volt,±5 V
+20512fd,LTC2051HVCMS10,min_op_temp,0
+20512fd,LTC2051HVCMS10,max_op_temp,70
+20512fd,LTC2051IDD,part_family,N
+20512fd,LTC2051IDD,typ_gbp,3.0 MHz
+20512fd,LTC2051IDD,typ_supply_current,0.75 mA
+20512fd,LTC2051IDD,typ_supply_current,0.85 mA
+20512fd,LTC2051IDD,min_op_supply_volt,3 V
+20512fd,LTC2051IDD,max_op_supply_volt,5 V
+20512fd,LTC2051IDD,min_op_temp,-40
+20512fd,LTC2051IDD,max_op_temp,85
+20512fd,LTC2051IS8,part_family,N
+20512fd,LTC2051IS8,typ_gbp,3.0 MHz
+20512fd,LTC2051IS8,typ_supply_current,0.75 mA
+20512fd,LTC2051IS8,typ_supply_current,0.85 mA
+20512fd,LTC2051IS8,min_op_supply_volt,3 V
+20512fd,LTC2051IS8,max_op_supply_volt,5 V
+20512fd,LTC2051IS8,min_op_temp,-40
+20512fd,LTC2051IS8,max_op_temp,85
+20512fd,LTC2051IMS8,part_family,N
+20512fd,LTC2051IMS8,typ_gbp,3.0 MHz
+20512fd,LTC2051IMS8,typ_supply_current,0.75 mA
+20512fd,LTC2051IMS8,typ_supply_current,0.85 mA
+20512fd,LTC2051IMS8,min_op_supply_volt,3 V
+20512fd,LTC2051IMS8,max_op_supply_volt,5 V
+20512fd,LTC2051IMS8,min_op_temp,-40
+20512fd,LTC2051IMS8,max_op_temp,85
+20512fd,LTC2051IMS10,part_family,N
+20512fd,LTC2051IMS10,typ_gbp,3.0 MHz
+20512fd,LTC2051IMS10,typ_supply_current,0.75 mA
+20512fd,LTC2051IMS10,typ_supply_current,0.85 mA
+20512fd,LTC2051IMS10,min_op_supply_volt,3 V
+20512fd,LTC2051IMS10,max_op_supply_volt,5 V
+20512fd,LTC2051IMS10,min_op_temp,-40
+20512fd,LTC2051IMS10,max_op_temp,85
+20512fd,LTC2051HVIDD,part_family,N
+20512fd,LTC2051HVIDD,typ_gbp,3.0 MHz
+20512fd,LTC2051HVIDD,typ_supply_current,0.75 mA
+20512fd,LTC2051HVIDD,typ_supply_current,0.85 mA
+20512fd,LTC2051HVIDD,min_op_supply_volt,3 V
+20512fd,LTC2051HVIDD,max_op_supply_volt,5 V
+20512fd,LTC2051HVIDD,max_op_supply_volt,±5 V
+20512fd,LTC2051HVIDD,min_op_temp,-40
+20512fd,LTC2051HVIDD,max_op_temp,85
+20512fd,LTC2051HVIS8,part_family,N
+20512fd,LTC2051HVIS8,typ_gbp,3.0 MHz
+20512fd,LTC2051HVIS8,typ_supply_current,0.75 mA
+20512fd,LTC2051HVIS8,typ_supply_current,0.85 mA
+20512fd,LTC2051HVIS8,min_op_supply_volt,3 V
+20512fd,LTC2051HVIS8,max_op_supply_volt,5 V
+20512fd,LTC2051HVIS8,max_op_supply_volt,±5 V
+20512fd,LTC2051HVIS8,min_op_temp,-40
+20512fd,LTC2051HVIS8,max_op_temp,85
+20512fd,LTC2051HVIMS8,part_family,N
+20512fd,LTC2051HVIMS8,typ_gbp,3.0 MHz
+20512fd,LTC2051HVIMS8,typ_supply_current,0.75 mA
+20512fd,LTC2051HVIMS8,typ_supply_current,0.85 mA
+20512fd,LTC2051HVIMS8,min_op_supply_volt,3 V
+20512fd,LTC2051HVIMS8,max_op_supply_volt,5 V
+20512fd,LTC2051HVIMS8,max_op_supply_volt,±5 V
+20512fd,LTC2051HVIMS8,min_op_temp,-40
+20512fd,LTC2051HVIMS8,max_op_temp,85
+20512fd,LTC2051HVIMS10,part_family,N
+20512fd,LTC2051HVIMS10,typ_gbp,3.0 MHz
+20512fd,LTC2051HVIMS10,typ_supply_current,0.75 mA
+20512fd,LTC2051HVIMS10,typ_supply_current,0.85 mA
+20512fd,LTC2051HVIMS10,min_op_supply_volt,3 V
+20512fd,LTC2051HVIMS10,max_op_supply_volt,5 V
+20512fd,LTC2051HVIMS10,max_op_supply_volt,±5 V
+20512fd,LTC2051HVIMS10,min_op_temp,-40
+20512fd,LTC2051HVIMS10,max_op_temp,85
+20512fd,LTC2051HS8,part_family,N
+20512fd,LTC2051HS8,typ_gbp,3.0 MHz
+20512fd,LTC2051HS8,typ_supply_current,0.75 mA
+20512fd,LTC2051HS8,typ_supply_current,0.85 mA
+20512fd,LTC2051HS8,min_op_supply_volt,3 V
+20512fd,LTC2051HS8,max_op_supply_volt,5 V
+20512fd,LTC2051HS8,min_op_temp,-40
+20512fd,LTC2051HS8,max_op_temp,125
+20512fd,LTC2051HMS8,part_family,N
+20512fd,LTC2051HMS8,typ_gbp,3.0 MHz
+20512fd,LTC2051HMS8,typ_supply_current,0.75 mA
+20512fd,LTC2051HMS8,typ_supply_current,0.85 mA
+20512fd,LTC2051HMS8,min_op_supply_volt,3 V
+20512fd,LTC2051HMS8,max_op_supply_volt,5 V
+20512fd,LTC2051HMS8,min_op_temp,-40
+20512fd,LTC2051HMS8,max_op_temp,125
+20512fd,LTC2051HVHS8,part_family,N
+20512fd,LTC2051HVHS8,typ_gbp,3.0 MHz
+20512fd,LTC2051HVHS8,typ_supply_current,0.75 mA
+20512fd,LTC2051HVHS8,typ_supply_current,0.85 mA
+20512fd,LTC2051HVHS8,min_op_supply_volt,3 V
+20512fd,LTC2051HVHS8,max_op_supply_volt,5 V
+20512fd,LTC2051HVHS8,max_op_supply_volt,±5 V
+20512fd,LTC2051HVHS8,min_op_temp,-40
+20512fd,LTC2051HVHS8,max_op_temp,125
+20512fd,LTC2051HVHMS8,part_family,N
+20512fd,LTC2051HVHMS8,typ_gbp,3.0 MHz
+20512fd,LTC2051HVHMS8,typ_supply_current,0.75 mA
+20512fd,LTC2051HVHMS8,typ_supply_current,0.85 mA
+20512fd,LTC2051HVHMS8,min_op_supply_volt,3 V
+20512fd,LTC2051HVHMS8,max_op_supply_volt,5 V
+20512fd,LTC2051HVHMS8,max_op_supply_volt,±5 V
+20512fd,LTC2051HVHMS8,min_op_temp,-40
+20512fd,LTC2051HVHMS8,max_op_temp,125
+20512fd,LTC2052,part_family,Y
+20512fd,LTC2052,typ_gbp,3.0 MHz
+20512fd,LTC2052,typ_supply_current,0.75 mA
+20512fd,LTC2052,typ_supply_current,0.85 mA
+20512fd,LTC2052CS,part_family,N
+20512fd,LTC2052CS,typ_gbp,3.0 MHz
+20512fd,LTC2052CS,typ_supply_current,0.75 mA
+20512fd,LTC2052CS,typ_supply_current,0.85 mA
+20512fd,LTC2052CS,min_op_supply_volt,3 V
+20512fd,LTC2052CS,max_op_supply_volt,5 V
+20512fd,LTC2052CS,min_op_temp,0
+20512fd,LTC2052CS,max_op_temp,70
+20512fd,LTC2052CGN,part_family,N
+20512fd,LTC2052CGN,typ_gbp,3.0 MHz
+20512fd,LTC2052CGN,typ_supply_current,0.75 mA
+20512fd,LTC2052CGN,typ_supply_current,0.85 mA
+20512fd,LTC2052CGN,min_op_supply_volt,3 V
+20512fd,LTC2052CGN,max_op_supply_volt,5 V
+20512fd,LTC2052CGN,min_op_temp,0
+20512fd,LTC2052CGN,max_op_temp,70
+20512fd,LTC2052HVCS,part_family,N
+20512fd,LTC2052HVCS,typ_gbp,3.0 MHz
+20512fd,LTC2052HVCS,typ_supply_current,0.75 mA
+20512fd,LTC2052HVCS,typ_supply_current,0.85 mA
+20512fd,LTC2052HVCS,min_op_supply_volt,3 V
+20512fd,LTC2052HVCS,max_op_supply_volt,5 V
+20512fd,LTC2052HVCS,max_op_supply_volt,±5 V
+20512fd,LTC2052HVCS,min_op_temp,0
+20512fd,LTC2052HVCS,max_op_temp,70
+20512fd,LTC2052HVCGN,part_family,N
+20512fd,LTC2052HVCGN,typ_gbp,3.0 MHz
+20512fd,LTC2052HVCGN,typ_supply_current,0.75 mA
+20512fd,LTC2052HVCGN,typ_supply_current,0.85 mA
+20512fd,LTC2052HVCGN,min_op_supply_volt,3 V
+20512fd,LTC2052HVCGN,max_op_supply_volt,5 V
+20512fd,LTC2052HVCGN,max_op_supply_volt,±5 V
+20512fd,LTC2052HVCGN,min_op_temp,0
+20512fd,LTC2052HVCGN,max_op_temp,70
+20512fd,LTC2052IS,part_family,N
+20512fd,LTC2052IS,typ_gbp,3.0 MHz
+20512fd,LTC2052IS,typ_supply_current,0.75 mA
+20512fd,LTC2052IS,typ_supply_current,0.85 mA
+20512fd,LTC2052IS,min_op_supply_volt,3 V
+20512fd,LTC2052IS,max_op_supply_volt,5 V
+20512fd,LTC2052IS,min_op_temp,-40
+20512fd,LTC2052IS,max_op_temp,85
+20512fd,LTC2052IGN,part_family,N
+20512fd,LTC2052IGN,typ_gbp,3.0 MHz
+20512fd,LTC2052IGN,typ_supply_current,0.75 mA
+20512fd,LTC2052IGN,typ_supply_current,0.85 mA
+20512fd,LTC2052IGN,min_op_supply_volt,3 V
+20512fd,LTC2052IGN,max_op_supply_volt,5 V
+20512fd,LTC2052IGN,min_op_temp,-40
+20512fd,LTC2052IGN,max_op_temp,85
+20512fd,LTC2052HVIS,part_family,N
+20512fd,LTC2052HVIS,typ_gbp,3.0 MHz
+20512fd,LTC2052HVIS,typ_supply_current,0.75 mA
+20512fd,LTC2052HVIS,typ_supply_current,0.85 mA
+20512fd,LTC2052HVIS,min_op_supply_volt,3 V
+20512fd,LTC2052HVIS,max_op_supply_volt,5 V
+20512fd,LTC2052HVIS,max_op_supply_volt,±5 V
+20512fd,LTC2052HVIS,min_op_temp,-40
+20512fd,LTC2052HVIS,max_op_temp,85
+20512fd,LTC2052HVIGN,part_family,N
+20512fd,LTC2052HVIGN,typ_gbp,3.0 MHz
+20512fd,LTC2052HVIGN,typ_supply_current,0.75 mA
+20512fd,LTC2052HVIGN,typ_supply_current,0.85 mA
+20512fd,LTC2052HVIGN,min_op_supply_volt,3 V
+20512fd,LTC2052HVIGN,max_op_supply_volt,5 V
+20512fd,LTC2052HVIGN,max_op_supply_volt,±5 V
+20512fd,LTC2052HVIGN,min_op_temp,-40
+20512fd,LTC2052HVIGN,max_op_temp,85
+20512fd,LTC2052HS,part_family,N
+20512fd,LTC2052HS,typ_gbp,3.0 MHz
+20512fd,LTC2052HS,typ_supply_current,0.75 mA
+20512fd,LTC2052HS,typ_supply_current,0.85 mA
+20512fd,LTC2052HS,min_op_supply_volt,3 V
+20512fd,LTC2052HS,max_op_supply_volt,5 V
+20512fd,LTC2052HS,min_op_temp,-40
+20512fd,LTC2052HS,max_op_temp,125
+20512fd,LTC2052HGN,part_family,N
+20512fd,LTC2052HGN,typ_gbp,3.0 MHz
+20512fd,LTC2052HGN,typ_supply_current,0.75 mA
+20512fd,LTC2052HGN,typ_supply_current,0.85 mA
+20512fd,LTC2052HGN,min_op_supply_volt,3 V
+20512fd,LTC2052HGN,max_op_supply_volt,5 V
+20512fd,LTC2052HGN,min_op_temp,-40
+20512fd,LTC2052HGN,max_op_temp,125
+20512fd,LTC2052HVHS,part_family,N
+20512fd,LTC2052HVHS,typ_gbp,3.0 MHz
+20512fd,LTC2052HVHS,typ_supply_current,0.75 mA
+20512fd,LTC2052HVHS,typ_supply_current,0.85 mA
+20512fd,LTC2052HVHS,min_op_supply_volt,3 V
+20512fd,LTC2052HVHS,max_op_supply_volt,5 V
+20512fd,LTC2052HVHS,max_op_supply_volt,±5 V
+20512fd,LTC2052HVHS,min_op_temp,-40
+20512fd,LTC2052HVHS,max_op_temp,125
+20512fd,LTC2052HVHGN,part_family,N
+20512fd,LTC2052HVHGN,typ_gbp,3.0 MHz
+20512fd,LTC2052HVHGN,typ_supply_current,0.75 mA
+20512fd,LTC2052HVHGN,typ_supply_current,0.85 mA
+20512fd,LTC2052HVHGN,min_op_supply_volt,3 V
+20512fd,LTC2052HVHGN,max_op_supply_volt,5 V
+20512fd,LTC2052HVHGN,max_op_supply_volt,±5 V
+20512fd,LTC2052HVHGN,min_op_temp,-40
+20512fd,LTC2052HVHGN,max_op_temp,125
+ad620,AD620,part_family,Y
+ad620,AD620,typ_supply_current,0.9 mA
+ad620,AD620,min_op_supply_volt,±2.3 V
+ad620,AD620,max_op_supply_volt,±18 V
+ad620,AD620AN,part_family,N
+ad620,AD620AN,typ_supply_current,0.9 mA
+ad620,AD620AN,min_op_supply_volt,±2.3 V
+ad620,AD620AN,max_op_supply_volt,±18 V
+ad620,AD620AN,min_op_temp,-40
+ad620,AD620AN,max_op_temp,85
+ad620,AD620ANZ,part_family,N
+ad620,AD620ANZ,typ_supply_current,0.9 mA
+ad620,AD620ANZ,min_op_supply_volt,±2.3 V
+ad620,AD620ANZ,max_op_supply_volt,±18 V
+ad620,AD620ANZ,min_op_temp,-40
+ad620,AD620ANZ,max_op_temp,85
+ad620,AD620BN,part_family,N
+ad620,AD620BN,typ_supply_current,0.9 mA
+ad620,AD620BN,min_op_supply_volt,±2.3 V
+ad620,AD620BN,max_op_supply_volt,±18 V
+ad620,AD620BN,min_op_temp,-40
+ad620,AD620BN,max_op_temp,85
+ad620,AD620BNZ,part_family,N
+ad620,AD620BNZ,typ_supply_current,0.9 mA
+ad620,AD620BNZ,min_op_supply_volt,±2.3 V
+ad620,AD620BNZ,max_op_supply_volt,±18 V
+ad620,AD620BNZ,min_op_temp,-40
+ad620,AD620BNZ,max_op_temp,85
+ad620,AD620AR,part_family,N
+ad620,AD620AR,typ_supply_current,0.9 mA
+ad620,AD620AR,min_op_supply_volt,±2.3 V
+ad620,AD620AR,max_op_supply_volt,±18 V
+ad620,AD620AR,min_op_temp,-40
+ad620,AD620AR,max_op_temp,85
+ad620,AD620ARZ,part_family,N
+ad620,AD620ARZ,typ_supply_current,0.9 mA
+ad620,AD620ARZ,min_op_supply_volt,±2.3 V
+ad620,AD620ARZ,max_op_supply_volt,±18 V
+ad620,AD620ARZ,min_op_temp,-40
+ad620,AD620ARZ,max_op_temp,85
+ad620,AD620AR-REEL,part_family,N
+ad620,AD620AR-REEL,typ_supply_current,0.9 mA
+ad620,AD620AR-REEL,min_op_supply_volt,±2.3 V
+ad620,AD620AR-REEL,max_op_supply_volt,±18 V
+ad620,AD620AR-REEL,min_op_temp,-40
+ad620,AD620AR-REEL,max_op_temp,85
+ad620,AD620ARZ-REEL,part_family,N
+ad620,AD620ARZ-REEL,typ_supply_current,0.9 mA
+ad620,AD620ARZ-REEL,min_op_supply_volt,±2.3 V
+ad620,AD620ARZ-REEL,max_op_supply_volt,±18 V
+ad620,AD620ARZ-REEL,min_op_temp,-40
+ad620,AD620ARZ-REEL,max_op_temp,85
+ad620,AD620AR-REEL7,part_family,N
+ad620,AD620AR-REEL7,typ_supply_current,0.9 mA
+ad620,AD620AR-REEL7,min_op_supply_volt,±2.3 V
+ad620,AD620AR-REEL7,max_op_supply_volt,±18 V
+ad620,AD620AR-REEL7,min_op_temp,-40
+ad620,AD620AR-REEL7,max_op_temp,85
+ad620,AD620ARZ-REEL7,part_family,N
+ad620,AD620ARZ-REEL7,typ_supply_current,0.9 mA
+ad620,AD620ARZ-REEL7,min_op_supply_volt,±2.3 V
+ad620,AD620ARZ-REEL7,max_op_supply_volt,±18 V
+ad620,AD620ARZ-REEL7,min_op_temp,-40
+ad620,AD620ARZ-REEL7,max_op_temp,85
+ad620,AD620BR,part_family,N
+ad620,AD620BR,typ_supply_current,0.9 mA
+ad620,AD620BR,min_op_supply_volt,±2.3 V
+ad620,AD620BR,max_op_supply_volt,±18 V
+ad620,AD620BR,min_op_temp,-40
+ad620,AD620BR,max_op_temp,85
+ad620,AD620BRZ,part_family,N
+ad620,AD620BRZ,typ_supply_current,0.9 mA
+ad620,AD620BRZ,min_op_supply_volt,±2.3 V
+ad620,AD620BRZ,max_op_supply_volt,±18 V
+ad620,AD620BRZ,min_op_temp,-40
+ad620,AD620BRZ,max_op_temp,85
+ad620,AD620BR-REEL,part_family,N
+ad620,AD620BR-REEL,typ_supply_current,0.9 mA
+ad620,AD620BR-REEL,min_op_supply_volt,±2.3 V
+ad620,AD620BR-REEL,max_op_supply_volt,±18 V
+ad620,AD620BR-REEL,min_op_temp,-40
+ad620,AD620BR-REEL,max_op_temp,85
+ad620,AD620BRZ-RL,part_family,N
+ad620,AD620BRZ-RL,typ_supply_current,0.9 mA
+ad620,AD620BRZ-RL,min_op_supply_volt,±2.3 V
+ad620,AD620BRZ-RL,max_op_supply_volt,±18 V
+ad620,AD620BRZ-RL,min_op_temp,-40
+ad620,AD620BRZ-RL,max_op_temp,85
+ad620,AD620BR-REEL7,part_family,N
+ad620,AD620BR-REEL7,typ_supply_current,0.9 mA
+ad620,AD620BR-REEL7,min_op_supply_volt,±2.3 V
+ad620,AD620BR-REEL7,max_op_supply_volt,±18 V
+ad620,AD620BR-REEL7,min_op_temp,-40
+ad620,AD620BR-REEL7,max_op_temp,85
+ad620,AD620BRZ-R7,part_family,N
+ad620,AD620BRZ-R7,typ_supply_current,0.9 mA
+ad620,AD620BRZ-R7,min_op_supply_volt,±2.3 V
+ad620,AD620BRZ-R7,max_op_supply_volt,±18 V
+ad620,AD620BRZ-R7,min_op_temp,-40
+ad620,AD620BRZ-R7,max_op_temp,85
+ad620,AD620ACHIPS,part_family,N
+ad620,AD620ACHIPS,typ_supply_current,0.9 mA
+ad620,AD620ACHIPS,min_op_supply_volt,±2.3 V
+ad620,AD620ACHIPS,max_op_supply_volt,±18 V
+ad620,AD620ACHIPS,min_op_temp,-40
+ad620,AD620ACHIPS,max_op_temp,85
+ad620,AD620SQ/883B,part_family,N
+ad620,AD620SQ/883B,typ_supply_current,0.9 mA
+ad620,AD620SQ/883B,min_op_supply_volt,±2.3 V
+ad620,AD620SQ/883B,max_op_supply_volt,±18 V
+ad620,AD620SQ/883B,min_op_temp,-55
+ad620,AD620SQ/883B,max_op_temp,125
+ad746,AD746,part_family,Y
+ad746,AD746,typ_gbp,13.0 MHz
+ad746,AD746,typ_supply_current,7.0 mA
+ad746,AD746,min_op_supply_volt,±4.5 V
+ad746,AD746,max_op_supply_volt,±18 V
+ad746,AD746J,part_family,N
+ad746,AD746J,typ_gbp,13.0 MHz
+ad746,AD746J,typ_supply_current,7.0 mA
+ad746,AD746J,min_op_supply_volt,±4.5 V
+ad746,AD746J,max_op_supply_volt,±18 V
+ad746,AD746J,min_op_temp,0
+ad746,AD746J,max_op_temp,70
+ad746,AD746A,part_family,N
+ad746,AD746A,typ_gbp,13.0 MHz
+ad746,AD746A,typ_supply_current,7.0 mA
+ad746,AD746A,min_op_supply_volt,±4.5 V
+ad746,AD746A,max_op_supply_volt,±18 V
+ad746,AD746A,min_op_temp,-40
+ad746,AD746A,max_op_temp,85
+ad746,AD746B,part_family,N
+ad746,AD746B,typ_gbp,13.0 MHz
+ad746,AD746B,typ_supply_current,7.0 mA
+ad746,AD746B,min_op_supply_volt,±4.5 V
+ad746,AD746B,max_op_supply_volt,±18 V
+ad746,AD746B,min_op_temp,-40
+ad746,AD746B,max_op_temp,85
+ad746,AD746S,part_family,N
+ad746,AD746S,typ_gbp,13.0 MHz
+ad746,AD746S,typ_supply_current,7.0 mA
+ad746,AD746S,min_op_supply_volt,±4.5 V
+ad746,AD746S,max_op_supply_volt,±18 V
+ad746,AD746S,min_op_temp,-55
+ad746,AD746S,max_op_temp,125
+ad8014,AD8014,part_family,Y
+ad8014,AD8014,typ_supply_current,1.15 mA
+ad8014,AD8014,min_op_supply_volt,±2.25 V
+ad8014,AD8014,min_op_supply_volt,4.5 V
+ad8014,AD8014,max_op_supply_volt,±6.0 V
+ad8014,AD8014,max_op_supply_volt,12 V
+ad8014,AD8014,min_op_temp,-40
+ad8014,AD8014,max_op_temp,85
+ad8014,AD8014AR,part_family,N
+ad8014,AD8014AR,typ_supply_current,1.15 mA
+ad8014,AD8014AR,min_op_supply_volt,±2.25 V
+ad8014,AD8014AR,min_op_supply_volt,4.5 V
+ad8014,AD8014AR,max_op_supply_volt,±6.0 V
+ad8014,AD8014AR,max_op_supply_volt,12 V
+ad8014,AD8014AR,min_op_temp,-40
+ad8014,AD8014AR,max_op_temp,85
+ad8014,AD8014AR-REEL7,part_family,N
+ad8014,AD8014AR-REEL7,typ_supply_current,1.15 mA
+ad8014,AD8014AR-REEL7,min_op_supply_volt,±2.25 V
+ad8014,AD8014AR-REEL7,min_op_supply_volt,4.5 V
+ad8014,AD8014AR-REEL7,max_op_supply_volt,±6.0 V
+ad8014,AD8014AR-REEL7,max_op_supply_volt,12 V
+ad8014,AD8014AR-REEL7,min_op_temp,-40
+ad8014,AD8014AR-REEL7,max_op_temp,85
+ad8014,AD8014ARZ,part_family,N
+ad8014,AD8014ARZ,typ_supply_current,1.15 mA
+ad8014,AD8014ARZ,min_op_supply_volt,±2.25 V
+ad8014,AD8014ARZ,min_op_supply_volt,4.5 V
+ad8014,AD8014ARZ,max_op_supply_volt,±6.0 V
+ad8014,AD8014ARZ,max_op_supply_volt,12 V
+ad8014,AD8014ARZ,min_op_temp,-40
+ad8014,AD8014ARZ,max_op_temp,85
+ad8014,AD8014ARZ-REEL,part_family,N
+ad8014,AD8014ARZ-REEL,typ_supply_current,1.15 mA
+ad8014,AD8014ARZ-REEL,min_op_supply_volt,±2.25 V
+ad8014,AD8014ARZ-REEL,min_op_supply_volt,4.5 V
+ad8014,AD8014ARZ-REEL,max_op_supply_volt,±6.0 V
+ad8014,AD8014ARZ-REEL,max_op_supply_volt,12 V
+ad8014,AD8014ARZ-REEL,min_op_temp,-40
+ad8014,AD8014ARZ-REEL,max_op_temp,85
+ad8014,AD8014ARZ-REEL7,part_family,N
+ad8014,AD8014ARZ-REEL7,typ_supply_current,1.15 mA
+ad8014,AD8014ARZ-REEL7,min_op_supply_volt,±2.25 V
+ad8014,AD8014ARZ-REEL7,min_op_supply_volt,4.5 V
+ad8014,AD8014ARZ-REEL7,max_op_supply_volt,±6.0 V
+ad8014,AD8014ARZ-REEL7,max_op_supply_volt,12 V
+ad8014,AD8014ARZ-REEL7,min_op_temp,-40
+ad8014,AD8014ARZ-REEL7,max_op_temp,85
+ad8014,AD8014ART-R2,part_family,N
+ad8014,AD8014ART-R2,typ_supply_current,1.15 mA
+ad8014,AD8014ART-R2,min_op_supply_volt,±2.25 V
+ad8014,AD8014ART-R2,min_op_supply_volt,4.5 V
+ad8014,AD8014ART-R2,max_op_supply_volt,±6.0 V
+ad8014,AD8014ART-R2,max_op_supply_volt,12 V
+ad8014,AD8014ART-R2,min_op_temp,-40
+ad8014,AD8014ART-R2,max_op_temp,85
+ad8014,AD8014ART-REEL7,part_family,N
+ad8014,AD8014ART-REEL7,typ_supply_current,1.15 mA
+ad8014,AD8014ART-REEL7,min_op_supply_volt,±2.25 V
+ad8014,AD8014ART-REEL7,min_op_supply_volt,4.5 V
+ad8014,AD8014ART-REEL7,max_op_supply_volt,±6.0 V
+ad8014,AD8014ART-REEL7,max_op_supply_volt,12 V
+ad8014,AD8014ART-REEL7,min_op_temp,-40
+ad8014,AD8014ART-REEL7,max_op_temp,85
+ad8014,AD8014ARTZ-R2,part_family,N
+ad8014,AD8014ARTZ-R2,typ_supply_current,1.15 mA
+ad8014,AD8014ARTZ-R2,min_op_supply_volt,±2.25 V
+ad8014,AD8014ARTZ-R2,min_op_supply_volt,4.5 V
+ad8014,AD8014ARTZ-R2,max_op_supply_volt,±6.0 V
+ad8014,AD8014ARTZ-R2,max_op_supply_volt,12 V
+ad8014,AD8014ARTZ-R2,min_op_temp,-40
+ad8014,AD8014ARTZ-R2,max_op_temp,85
+ad8014,AD8014ARTZ-REEL,part_family,N
+ad8014,AD8014ARTZ-REEL,typ_supply_current,1.15 mA
+ad8014,AD8014ARTZ-REEL,min_op_supply_volt,±2.25 V
+ad8014,AD8014ARTZ-REEL,min_op_supply_volt,4.5 V
+ad8014,AD8014ARTZ-REEL,max_op_supply_volt,±6.0 V
+ad8014,AD8014ARTZ-REEL,max_op_supply_volt,12 V
+ad8014,AD8014ARTZ-REEL,min_op_temp,-40
+ad8014,AD8014ARTZ-REEL,max_op_temp,85
+ad8014,AD8014ARTZ-REEL7,part_family,N
+ad8014,AD8014ARTZ-REEL7,typ_supply_current,1.15 mA
+ad8014,AD8014ARTZ-REEL7,min_op_supply_volt,±2.25 V
+ad8014,AD8014ARTZ-REEL7,min_op_supply_volt,4.5 V
+ad8014,AD8014ARTZ-REEL7,max_op_supply_volt,±6.0 V
+ad8014,AD8014ARTZ-REEL7,max_op_supply_volt,12 V
+ad8014,AD8014ARTZ-REEL7,min_op_temp,-40
+ad8014,AD8014ARTZ-REEL7,max_op_temp,85
+ad8029_8030_8040,AD8029,part_family,Y
+ad8029_8030_8040,AD8029,typ_supply_current,1.3 mA
+ad8029_8030_8040,AD8029,min_op_supply_volt,2.7 V
+ad8029_8030_8040,AD8029,max_op_supply_volt,12 V
+ad8029_8030_8040,AD8029,min_op_temp,-40
+ad8029_8030_8040,AD8029,max_op_temp,125
+ad8029_8030_8040,AD8029ARZ,part_family,N
+ad8029_8030_8040,AD8029ARZ,typ_supply_current,1.3 mA
+ad8029_8030_8040,AD8029ARZ,min_op_supply_volt,2.7 V
+ad8029_8030_8040,AD8029ARZ,max_op_supply_volt,12 V
+ad8029_8030_8040,AD8029ARZ,min_op_temp,-40
+ad8029_8030_8040,AD8029ARZ,max_op_temp,125
+ad8029_8030_8040,AD8029AR-REEL,part_family,N
+ad8029_8030_8040,AD8029AR-REEL,typ_supply_current,1.3 mA
+ad8029_8030_8040,AD8029AR-REEL,min_op_supply_volt,2.7 V
+ad8029_8030_8040,AD8029AR-REEL,max_op_supply_volt,12 V
+ad8029_8030_8040,AD8029AR-REEL,min_op_temp,-40
+ad8029_8030_8040,AD8029AR-REEL,max_op_temp,125
+ad8029_8030_8040,AD8029ARZ-REEL,part_family,N
+ad8029_8030_8040,AD8029ARZ-REEL,typ_supply_current,1.3 mA
+ad8029_8030_8040,AD8029ARZ-REEL,min_op_supply_volt,2.7 V
+ad8029_8030_8040,AD8029ARZ-REEL,max_op_supply_volt,12 V
+ad8029_8030_8040,AD8029ARZ-REEL,min_op_temp,-40
+ad8029_8030_8040,AD8029ARZ-REEL,max_op_temp,125
+ad8029_8030_8040,AD8029AR-REEL7,part_family,N
+ad8029_8030_8040,AD8029AR-REEL7,typ_supply_current,1.3 mA
+ad8029_8030_8040,AD8029AR-REEL7,min_op_supply_volt,2.7 V
+ad8029_8030_8040,AD8029AR-REEL7,max_op_supply_volt,12 V
+ad8029_8030_8040,AD8029AR-REEL7,min_op_temp,-40
+ad8029_8030_8040,AD8029AR-REEL7,max_op_temp,125
+ad8029_8030_8040,AD8029ARZ-REEL7,part_family,N
+ad8029_8030_8040,AD8029ARZ-REEL7,typ_supply_current,1.3 mA
+ad8029_8030_8040,AD8029ARZ-REEL7,min_op_supply_volt,2.7 V
+ad8029_8030_8040,AD8029ARZ-REEL7,max_op_supply_volt,12 V
+ad8029_8030_8040,AD8029ARZ-REEL7,min_op_temp,-40
+ad8029_8030_8040,AD8029ARZ-REEL7,max_op_temp,125
+ad8029_8030_8040,AD8029AKSZ-R2,part_family,N
+ad8029_8030_8040,AD8029AKSZ-R2,typ_supply_current,1.3 mA
+ad8029_8030_8040,AD8029AKSZ-R2,min_op_supply_volt,2.7 V
+ad8029_8030_8040,AD8029AKSZ-R2,max_op_supply_volt,12 V
+ad8029_8030_8040,AD8029AKSZ-R2,min_op_temp,-40
+ad8029_8030_8040,AD8029AKSZ-R2,max_op_temp,125
+ad8029_8030_8040,AD8029AKSZ-REEL,part_family,N
+ad8029_8030_8040,AD8029AKSZ-REEL,typ_supply_current,1.3 mA
+ad8029_8030_8040,AD8029AKSZ-REEL,min_op_supply_volt,2.7 V
+ad8029_8030_8040,AD8029AKSZ-REEL,max_op_supply_volt,12 V
+ad8029_8030_8040,AD8029AKSZ-REEL,min_op_temp,-40
+ad8029_8030_8040,AD8029AKSZ-REEL,max_op_temp,125
+ad8029_8030_8040,AD8029AKSZ-REEL7,part_family,N
+ad8029_8030_8040,AD8029AKSZ-REEL7,typ_supply_current,1.3 mA
+ad8029_8030_8040,AD8029AKSZ-REEL7,min_op_supply_volt,2.7 V
+ad8029_8030_8040,AD8029AKSZ-REEL7,max_op_supply_volt,12 V
+ad8029_8030_8040,AD8029AKSZ-REEL7,min_op_temp,-40
+ad8029_8030_8040,AD8029AKSZ-REEL7,max_op_temp,125
+ad8029_8030_8040,AD8030,part_family,Y
+ad8029_8030_8040,AD8030,typ_supply_current,1.3 mA
+ad8029_8030_8040,AD8030,min_op_supply_volt,2.7 V
+ad8029_8030_8040,AD8030,max_op_supply_volt,12 V
+ad8029_8030_8040,AD8030,min_op_temp,-40
+ad8029_8030_8040,AD8030,max_op_temp,125
+ad8029_8030_8040,AD8030AR,part_family,N
+ad8029_8030_8040,AD8030AR,typ_supply_current,1.3 mA
+ad8029_8030_8040,AD8030AR,min_op_supply_volt,2.7 V
+ad8029_8030_8040,AD8030AR,max_op_supply_volt,12 V
+ad8029_8030_8040,AD8030AR,min_op_temp,-40
+ad8029_8030_8040,AD8030AR,max_op_temp,125
+ad8029_8030_8040,AD8030ARZ,part_family,N
+ad8029_8030_8040,AD8030ARZ,typ_supply_current,1.3 mA
+ad8029_8030_8040,AD8030ARZ,min_op_supply_volt,2.7 V
+ad8029_8030_8040,AD8030ARZ,max_op_supply_volt,12 V
+ad8029_8030_8040,AD8030ARZ,min_op_temp,-40
+ad8029_8030_8040,AD8030ARZ,max_op_temp,125
+ad8029_8030_8040,AD8030ARZ-REEL,part_family,N
+ad8029_8030_8040,AD8030ARZ-REEL,typ_supply_current,1.3 mA
+ad8029_8030_8040,AD8030ARZ-REEL,min_op_supply_volt,2.7 V
+ad8029_8030_8040,AD8030ARZ-REEL,max_op_supply_volt,12 V
+ad8029_8030_8040,AD8030ARZ-REEL,min_op_temp,-40
+ad8029_8030_8040,AD8030ARZ-REEL,max_op_temp,125
+ad8029_8030_8040,AD8030ARZ-REEL7,part_family,N
+ad8029_8030_8040,AD8030ARZ-REEL7,typ_supply_current,1.3 mA
+ad8029_8030_8040,AD8030ARZ-REEL7,min_op_supply_volt,2.7 V
+ad8029_8030_8040,AD8030ARZ-REEL7,max_op_supply_volt,12 V
+ad8029_8030_8040,AD8030ARZ-REEL7,min_op_temp,-40
+ad8029_8030_8040,AD8030ARZ-REEL7,max_op_temp,125
+ad8029_8030_8040,AD8030ARJZ-R2,part_family,N
+ad8029_8030_8040,AD8030ARJZ-R2,typ_supply_current,1.3 mA
+ad8029_8030_8040,AD8030ARJZ-R2,min_op_supply_volt,2.7 V
+ad8029_8030_8040,AD8030ARJZ-R2,max_op_supply_volt,12 V
+ad8029_8030_8040,AD8030ARJZ-R2,min_op_temp,-40
+ad8029_8030_8040,AD8030ARJZ-R2,max_op_temp,125
+ad8029_8030_8040,AD8030ARJZ-REEL,part_family,N
+ad8029_8030_8040,AD8030ARJZ-REEL,typ_supply_current,1.3 mA
+ad8029_8030_8040,AD8030ARJZ-REEL,min_op_supply_volt,2.7 V
+ad8029_8030_8040,AD8030ARJZ-REEL,max_op_supply_volt,12 V
+ad8029_8030_8040,AD8030ARJZ-REEL,min_op_temp,-40
+ad8029_8030_8040,AD8030ARJZ-REEL,max_op_temp,125
+ad8029_8030_8040,AD8030ARJZ-REEL7,part_family,N
+ad8029_8030_8040,AD8030ARJZ-REEL7,typ_supply_current,1.3 mA
+ad8029_8030_8040,AD8030ARJZ-REEL7,min_op_supply_volt,2.7 V
+ad8029_8030_8040,AD8030ARJZ-REEL7,max_op_supply_volt,12 V
+ad8029_8030_8040,AD8030ARJZ-REEL7,min_op_temp,-40
+ad8029_8030_8040,AD8030ARJZ-REEL7,max_op_temp,125
+ad8029_8030_8040,AD8040,part_family,Y
+ad8029_8030_8040,AD8040,typ_supply_current,1.3 mA
+ad8029_8030_8040,AD8040,min_op_supply_volt,2.7 V
+ad8029_8030_8040,AD8040,max_op_supply_volt,12 V
+ad8029_8030_8040,AD8040,min_op_temp,-40
+ad8029_8030_8040,AD8040,max_op_temp,125
+ad8029_8030_8040,AD8040ARZ,part_family,N
+ad8029_8030_8040,AD8040ARZ,typ_supply_current,1.3 mA
+ad8029_8030_8040,AD8040ARZ,min_op_supply_volt,2.7 V
+ad8029_8030_8040,AD8040ARZ,max_op_supply_volt,12 V
+ad8029_8030_8040,AD8040ARZ,min_op_temp,-40
+ad8029_8030_8040,AD8040ARZ,max_op_temp,125
+ad8029_8030_8040,AD8040ARZ-REEL,part_family,N
+ad8029_8030_8040,AD8040ARZ-REEL,typ_supply_current,1.3 mA
+ad8029_8030_8040,AD8040ARZ-REEL,min_op_supply_volt,2.7 V
+ad8029_8030_8040,AD8040ARZ-REEL,max_op_supply_volt,12 V
+ad8029_8030_8040,AD8040ARZ-REEL,min_op_temp,-40
+ad8029_8030_8040,AD8040ARZ-REEL,max_op_temp,125
+ad8029_8030_8040,AD8040ARZ-REEL7,part_family,N
+ad8029_8030_8040,AD8040ARZ-REEL7,typ_supply_current,1.3 mA
+ad8029_8030_8040,AD8040ARZ-REEL7,min_op_supply_volt,2.7 V
+ad8029_8030_8040,AD8040ARZ-REEL7,max_op_supply_volt,12 V
+ad8029_8030_8040,AD8040ARZ-REEL7,min_op_temp,-40
+ad8029_8030_8040,AD8040ARZ-REEL7,max_op_temp,125
+ad8029_8030_8040,AD8040ARUZ,part_family,N
+ad8029_8030_8040,AD8040ARUZ,typ_supply_current,1.3 mA
+ad8029_8030_8040,AD8040ARUZ,min_op_supply_volt,2.7 V
+ad8029_8030_8040,AD8040ARUZ,max_op_supply_volt,12 V
+ad8029_8030_8040,AD8040ARUZ,min_op_temp,-40
+ad8029_8030_8040,AD8040ARUZ,max_op_temp,125
+ad8029_8030_8040,AD8040ARU-REEL,part_family,N
+ad8029_8030_8040,AD8040ARU-REEL,typ_supply_current,1.3 mA
+ad8029_8030_8040,AD8040ARU-REEL,min_op_supply_volt,2.7 V
+ad8029_8030_8040,AD8040ARU-REEL,max_op_supply_volt,12 V
+ad8029_8030_8040,AD8040ARU-REEL,min_op_temp,-40
+ad8029_8030_8040,AD8040ARU-REEL,max_op_temp,125
+ad8029_8030_8040,AD8040ARUZ-REEL,part_family,N
+ad8029_8030_8040,AD8040ARUZ-REEL,typ_supply_current,1.3 mA
+ad8029_8030_8040,AD8040ARUZ-REEL,min_op_supply_volt,2.7 V
+ad8029_8030_8040,AD8040ARUZ-REEL,max_op_supply_volt,12 V
+ad8029_8030_8040,AD8040ARUZ-REEL,min_op_temp,-40
+ad8029_8030_8040,AD8040ARUZ-REEL,max_op_temp,125
+ad8029_8030_8040,AD8040ARUZ-REEL7,part_family,N
+ad8029_8030_8040,AD8040ARUZ-REEL7,typ_supply_current,1.3 mA
+ad8029_8030_8040,AD8040ARUZ-REEL7,min_op_supply_volt,2.7 V
+ad8029_8030_8040,AD8040ARUZ-REEL7,max_op_supply_volt,12 V
+ad8029_8030_8040,AD8040ARUZ-REEL7,min_op_temp,-40
+ad8029_8030_8040,AD8040ARUZ-REEL7,max_op_temp,125
+ad8029_8030_8040,AD8040WARUZ-REEL7,part_family,N
+ad8029_8030_8040,AD8040WARUZ-REEL7,typ_supply_current,1.3 mA
+ad8029_8030_8040,AD8040WARUZ-REEL7,min_op_supply_volt,2.7 V
+ad8029_8030_8040,AD8040WARUZ-REEL7,max_op_supply_volt,12 V
+ad8029_8030_8040,AD8040WARUZ-REEL7,min_op_temp,-40
+ad8029_8030_8040,AD8040WARUZ-REEL7,max_op_temp,125
+ad8055_8056,AD8055,part_family,Y
+ad8055_8056,AD8055,typ_supply_current,5.4 mA
+ad8055_8056,AD8055,min_op_supply_volt,±4.0 V
+ad8055_8056,AD8055,max_op_supply_volt,±6.0 V
+ad8055_8056,AD8055,min_op_temp,-40
+ad8055_8056,AD8055,max_op_temp,125
+ad8055_8056,AD8055AN,part_family,N
+ad8055_8056,AD8055AN,typ_supply_current,5.4 mA
+ad8055_8056,AD8055AN,min_op_supply_volt,±4.0 V
+ad8055_8056,AD8055AN,max_op_supply_volt,±6.0 V
+ad8055_8056,AD8055AN,min_op_temp,-40
+ad8055_8056,AD8055AN,max_op_temp,125
+ad8055_8056,AD8055ANZ,part_family,N
+ad8055_8056,AD8055ANZ,typ_supply_current,5.4 mA
+ad8055_8056,AD8055ANZ,min_op_supply_volt,±4.0 V
+ad8055_8056,AD8055ANZ,max_op_supply_volt,±6.0 V
+ad8055_8056,AD8055ANZ,min_op_temp,-40
+ad8055_8056,AD8055ANZ,max_op_temp,125
+ad8055_8056,AD8055AR,part_family,N
+ad8055_8056,AD8055AR,typ_supply_current,5.4 mA
+ad8055_8056,AD8055AR,min_op_supply_volt,±4.0 V
+ad8055_8056,AD8055AR,max_op_supply_volt,±6.0 V
+ad8055_8056,AD8055AR,min_op_temp,-40
+ad8055_8056,AD8055AR,max_op_temp,125
+ad8055_8056,AD8055AR-REEL,part_family,N
+ad8055_8056,AD8055AR-REEL,typ_supply_current,5.4 mA
+ad8055_8056,AD8055AR-REEL,min_op_supply_volt,±4.0 V
+ad8055_8056,AD8055AR-REEL,max_op_supply_volt,±6.0 V
+ad8055_8056,AD8055AR-REEL,min_op_temp,-40
+ad8055_8056,AD8055AR-REEL,max_op_temp,125
+ad8055_8056,AD8055AR-REEL7,part_family,N
+ad8055_8056,AD8055AR-REEL7,typ_supply_current,5.4 mA
+ad8055_8056,AD8055AR-REEL7,min_op_supply_volt,±4.0 V
+ad8055_8056,AD8055AR-REEL7,max_op_supply_volt,±6.0 V
+ad8055_8056,AD8055AR-REEL7,min_op_temp,-40
+ad8055_8056,AD8055AR-REEL7,max_op_temp,125
+ad8055_8056,AD8055ARZ,part_family,N
+ad8055_8056,AD8055ARZ,typ_supply_current,5.4 mA
+ad8055_8056,AD8055ARZ,min_op_supply_volt,±4.0 V
+ad8055_8056,AD8055ARZ,max_op_supply_volt,±6.0 V
+ad8055_8056,AD8055ARZ,min_op_temp,-40
+ad8055_8056,AD8055ARZ,max_op_temp,125
+ad8055_8056,AD8055ARZ-REEL,part_family,N
+ad8055_8056,AD8055ARZ-REEL,typ_supply_current,5.4 mA
+ad8055_8056,AD8055ARZ-REEL,min_op_supply_volt,±4.0 V
+ad8055_8056,AD8055ARZ-REEL,max_op_supply_volt,±6.0 V
+ad8055_8056,AD8055ARZ-REEL,min_op_temp,-40
+ad8055_8056,AD8055ARZ-REEL,max_op_temp,125
+ad8055_8056,AD8055ARZ-REEL7,part_family,N
+ad8055_8056,AD8055ARZ-REEL7,typ_supply_current,5.4 mA
+ad8055_8056,AD8055ARZ-REEL7,min_op_supply_volt,±4.0 V
+ad8055_8056,AD8055ARZ-REEL7,max_op_supply_volt,±6.0 V
+ad8055_8056,AD8055ARZ-REEL7,min_op_temp,-40
+ad8055_8056,AD8055ARZ-REEL7,max_op_temp,125
+ad8055_8056,AD8055ART-R2,part_family,N
+ad8055_8056,AD8055ART-R2,typ_supply_current,5.4 mA
+ad8055_8056,AD8055ART-R2,min_op_supply_volt,±4.0 V
+ad8055_8056,AD8055ART-R2,max_op_supply_volt,±6.0 V
+ad8055_8056,AD8055ART-R2,min_op_temp,-40
+ad8055_8056,AD8055ART-R2,max_op_temp,125
+ad8055_8056,AD8055ART-REEL,part_family,N
+ad8055_8056,AD8055ART-REEL,typ_supply_current,5.4 mA
+ad8055_8056,AD8055ART-REEL,min_op_supply_volt,±4.0 V
+ad8055_8056,AD8055ART-REEL,max_op_supply_volt,±6.0 V
+ad8055_8056,AD8055ART-REEL,min_op_temp,-40
+ad8055_8056,AD8055ART-REEL,max_op_temp,125
+ad8055_8056,AD8055ART-REEL7,part_family,N
+ad8055_8056,AD8055ART-REEL7,typ_supply_current,5.4 mA
+ad8055_8056,AD8055ART-REEL7,min_op_supply_volt,±4.0 V
+ad8055_8056,AD8055ART-REEL7,max_op_supply_volt,±6.0 V
+ad8055_8056,AD8055ART-REEL7,min_op_temp,-40
+ad8055_8056,AD8055ART-REEL7,max_op_temp,125
+ad8055_8056,AD8055ARTZ-R2,part_family,N
+ad8055_8056,AD8055ARTZ-R2,typ_supply_current,5.4 mA
+ad8055_8056,AD8055ARTZ-R2,min_op_supply_volt,±4.0 V
+ad8055_8056,AD8055ARTZ-R2,max_op_supply_volt,±6.0 V
+ad8055_8056,AD8055ARTZ-R2,min_op_temp,-40
+ad8055_8056,AD8055ARTZ-R2,max_op_temp,125
+ad8055_8056,AD8055ARTZ-REEL7,part_family,N
+ad8055_8056,AD8055ARTZ-REEL7,typ_supply_current,5.4 mA
+ad8055_8056,AD8055ARTZ-REEL7,min_op_supply_volt,±4.0 V
+ad8055_8056,AD8055ARTZ-REEL7,max_op_supply_volt,±6.0 V
+ad8055_8056,AD8055ARTZ-REEL7,min_op_temp,-40
+ad8055_8056,AD8055ARTZ-REEL7,max_op_temp,125
+ad8055_8056,AD8056,part_family,Y
+ad8055_8056,AD8056,typ_supply_current,10.0 mA
+ad8055_8056,AD8056,min_op_supply_volt,±4.0 V
+ad8055_8056,AD8056,max_op_supply_volt,±6.0 V
+ad8055_8056,AD8056,min_op_temp,-40
+ad8055_8056,AD8056,max_op_temp,125
+ad8055_8056,AD8056AN,part_family,N
+ad8055_8056,AD8056AN,typ_supply_current,10.0 mA
+ad8055_8056,AD8056AN,min_op_supply_volt,±4.0 V
+ad8055_8056,AD8056AN,max_op_supply_volt,±6.0 V
+ad8055_8056,AD8056AN,min_op_temp,-40
+ad8055_8056,AD8056AN,max_op_temp,125
+ad8055_8056,AD8056ANZ,part_family,N
+ad8055_8056,AD8056ANZ,typ_supply_current,10.0 mA
+ad8055_8056,AD8056ANZ,min_op_supply_volt,±4.0 V
+ad8055_8056,AD8056ANZ,max_op_supply_volt,±6.0 V
+ad8055_8056,AD8056ANZ,min_op_temp,-40
+ad8055_8056,AD8056ANZ,max_op_temp,125
+ad8055_8056,AD8056AR,part_family,N
+ad8055_8056,AD8056AR,typ_supply_current,10.0 mA
+ad8055_8056,AD8056AR,min_op_supply_volt,±4.0 V
+ad8055_8056,AD8056AR,max_op_supply_volt,±6.0 V
+ad8055_8056,AD8056AR,min_op_temp,-40
+ad8055_8056,AD8056AR,max_op_temp,125
+ad8055_8056,AD8056AR-REEL,part_family,N
+ad8055_8056,AD8056AR-REEL,typ_supply_current,10.0 mA
+ad8055_8056,AD8056AR-REEL,min_op_supply_volt,±4.0 V
+ad8055_8056,AD8056AR-REEL,max_op_supply_volt,±6.0 V
+ad8055_8056,AD8056AR-REEL,min_op_temp,-40
+ad8055_8056,AD8056AR-REEL,max_op_temp,125
+ad8055_8056,AD8056AR-REEL7,part_family,N
+ad8055_8056,AD8056AR-REEL7,typ_supply_current,10.0 mA
+ad8055_8056,AD8056AR-REEL7,min_op_supply_volt,±4.0 V
+ad8055_8056,AD8056AR-REEL7,max_op_supply_volt,±6.0 V
+ad8055_8056,AD8056AR-REEL7,min_op_temp,-40
+ad8055_8056,AD8056AR-REEL7,max_op_temp,125
+ad8055_8056,AD8056ARZ,part_family,N
+ad8055_8056,AD8056ARZ,typ_supply_current,10.0 mA
+ad8055_8056,AD8056ARZ,min_op_supply_volt,±4.0 V
+ad8055_8056,AD8056ARZ,max_op_supply_volt,±6.0 V
+ad8055_8056,AD8056ARZ,min_op_temp,-40
+ad8055_8056,AD8056ARZ,max_op_temp,125
+ad8055_8056,AD8056ARZ-REEL,part_family,N
+ad8055_8056,AD8056ARZ-REEL,typ_supply_current,10.0 mA
+ad8055_8056,AD8056ARZ-REEL,min_op_supply_volt,±4.0 V
+ad8055_8056,AD8056ARZ-REEL,max_op_supply_volt,±6.0 V
+ad8055_8056,AD8056ARZ-REEL,min_op_temp,-40
+ad8055_8056,AD8056ARZ-REEL,max_op_temp,125
+ad8055_8056,AD8056ARZ-REEL7,part_family,N
+ad8055_8056,AD8056ARZ-REEL7,typ_supply_current,10.0 mA
+ad8055_8056,AD8056ARZ-REEL7,min_op_supply_volt,±4.0 V
+ad8055_8056,AD8056ARZ-REEL7,max_op_supply_volt,±6.0 V
+ad8055_8056,AD8056ARZ-REEL7,min_op_temp,-40
+ad8055_8056,AD8056ARZ-REEL7,max_op_temp,125
+ad8055_8056,AD8056ARM,part_family,N
+ad8055_8056,AD8056ARM,typ_supply_current,10.0 mA
+ad8055_8056,AD8056ARM,min_op_supply_volt,±4.0 V
+ad8055_8056,AD8056ARM,max_op_supply_volt,±6.0 V
+ad8055_8056,AD8056ARM,min_op_temp,-40
+ad8055_8056,AD8056ARM,max_op_temp,125
+ad8055_8056,AD8056ARM-REEL,part_family,N
+ad8055_8056,AD8056ARM-REEL,typ_supply_current,10.0 mA
+ad8055_8056,AD8056ARM-REEL,min_op_supply_volt,±4.0 V
+ad8055_8056,AD8056ARM-REEL,max_op_supply_volt,±6.0 V
+ad8055_8056,AD8056ARM-REEL,min_op_temp,-40
+ad8055_8056,AD8056ARM-REEL,max_op_temp,125
+ad8055_8056,AD8056ARM-REEL7,part_family,N
+ad8055_8056,AD8056ARM-REEL7,typ_supply_current,10.0 mA
+ad8055_8056,AD8056ARM-REEL7,min_op_supply_volt,±4.0 V
+ad8055_8056,AD8056ARM-REEL7,max_op_supply_volt,±6.0 V
+ad8055_8056,AD8056ARM-REEL7,min_op_temp,-40
+ad8055_8056,AD8056ARM-REEL7,max_op_temp,125
+ad8055_8056,AD8056ARMZ,part_family,N
+ad8055_8056,AD8056ARMZ,typ_supply_current,10.0 mA
+ad8055_8056,AD8056ARMZ,min_op_supply_volt,±4.0 V
+ad8055_8056,AD8056ARMZ,max_op_supply_volt,±6.0 V
+ad8055_8056,AD8056ARMZ,min_op_temp,-40
+ad8055_8056,AD8056ARMZ,max_op_temp,125
+ad8055_8056,AD8056ARMZ-REEL,part_family,N
+ad8055_8056,AD8056ARMZ-REEL,typ_supply_current,10.0 mA
+ad8055_8056,AD8056ARMZ-REEL,min_op_supply_volt,±4.0 V
+ad8055_8056,AD8056ARMZ-REEL,max_op_supply_volt,±6.0 V
+ad8055_8056,AD8056ARMZ-REEL,min_op_temp,-40
+ad8055_8056,AD8056ARMZ-REEL,max_op_temp,125
+ad8055_8056,AD8056ARMZ-REEL7,part_family,N
+ad8055_8056,AD8056ARMZ-REEL7,typ_supply_current,10.0 mA
+ad8055_8056,AD8056ARMZ-REEL7,min_op_supply_volt,±4.0 V
+ad8055_8056,AD8056ARMZ-REEL7,max_op_supply_volt,±6.0 V
+ad8055_8056,AD8056ARMZ-REEL7,min_op_temp,-40
+ad8055_8056,AD8056ARMZ-REEL7,max_op_temp,125
+ad8067,AD8067,part_family,Y
+ad8067,AD8067,typ_supply_current,6.5 mA
+ad8067,AD8067,typ_supply_current,6.4 mA
+ad8067,AD8067,typ_supply_current,6.6 mA
+ad8067,AD8067,min_op_supply_volt,5 V
+ad8067,AD8067,max_op_supply_volt,24 V
+ad8067,AD8067,min_op_temp,-40
+ad8067,AD8067,max_op_temp,85
+ad8067,AD8067ART-REEL,part_family,N
+ad8067,AD8067ART-REEL,typ_supply_current,6.5 mA
+ad8067,AD8067ART-REEL,typ_supply_current,6.4 mA
+ad8067,AD8067ART-REEL,typ_supply_current,6.6 mA
+ad8067,AD8067ART-REEL,min_op_supply_volt,5 V
+ad8067,AD8067ART-REEL,max_op_supply_volt,24 V
+ad8067,AD8067ART-REEL,min_op_temp,-40
+ad8067,AD8067ART-REEL,max_op_temp,85
+ad8067,AD8067ART-R2,part_family,N
+ad8067,AD8067ART-R2,typ_supply_current,6.5 mA
+ad8067,AD8067ART-R2,typ_supply_current,6.4 mA
+ad8067,AD8067ART-R2,typ_supply_current,6.6 mA
+ad8067,AD8067ART-R2,min_op_supply_volt,5 V
+ad8067,AD8067ART-R2,max_op_supply_volt,24 V
+ad8067,AD8067ART-R2,min_op_temp,-40
+ad8067,AD8067ART-R2,max_op_temp,85
+ad8067,AD8067ARTZ-REEL,part_family,N
+ad8067,AD8067ARTZ-REEL,typ_supply_current,6.5 mA
+ad8067,AD8067ARTZ-REEL,typ_supply_current,6.4 mA
+ad8067,AD8067ARTZ-REEL,typ_supply_current,6.6 mA
+ad8067,AD8067ARTZ-REEL,min_op_supply_volt,5 V
+ad8067,AD8067ARTZ-REEL,max_op_supply_volt,24 V
+ad8067,AD8067ARTZ-REEL,min_op_temp,-40
+ad8067,AD8067ARTZ-REEL,max_op_temp,85
+ad8067,AD8067ARTZ-REEL7,part_family,N
+ad8067,AD8067ARTZ-REEL7,typ_supply_current,6.5 mA
+ad8067,AD8067ARTZ-REEL7,typ_supply_current,6.4 mA
+ad8067,AD8067ARTZ-REEL7,typ_supply_current,6.6 mA
+ad8067,AD8067ARTZ-REEL7,min_op_supply_volt,5 V
+ad8067,AD8067ARTZ-REEL7,max_op_supply_volt,24 V
+ad8067,AD8067ARTZ-REEL7,min_op_temp,-40
+ad8067,AD8067ARTZ-REEL7,max_op_temp,85
+ad8067,AD8067ARTZ-R2,part_family,N
+ad8067,AD8067ARTZ-R2,typ_supply_current,6.5 mA
+ad8067,AD8067ARTZ-R2,typ_supply_current,6.4 mA
+ad8067,AD8067ARTZ-R2,typ_supply_current,6.6 mA
+ad8067,AD8067ARTZ-R2,min_op_supply_volt,5 V
+ad8067,AD8067ARTZ-R2,max_op_supply_volt,24 V
+ad8067,AD8067ARTZ-R2,min_op_temp,-40
+ad8067,AD8067ARTZ-R2,max_op_temp,85
+ad8220,AD8220,part_family,Y
+ad8220,AD8220,min_op_supply_volt,±2.25 V
+ad8220,AD8220,max_op_supply_volt,±18 V
+ad8220,AD8220ARMZ,part_family,N
+ad8220,AD8220ARMZ,min_op_supply_volt,±2.25 V
+ad8220,AD8220ARMZ,max_op_supply_volt,±18 V
+ad8220,AD8220ARMZ,min_op_temp,-40
+ad8220,AD8220ARMZ,max_op_temp,85
+ad8220,AD8220ARMZ-RL,part_family,N
+ad8220,AD8220ARMZ-RL,min_op_supply_volt,±2.25 V
+ad8220,AD8220ARMZ-RL,max_op_supply_volt,±18 V
+ad8220,AD8220ARMZ-RL,min_op_temp,-40
+ad8220,AD8220ARMZ-RL,max_op_temp,85
+ad8220,AD8220ARMZ-R7,part_family,N
+ad8220,AD8220ARMZ-R7,min_op_supply_volt,±2.25 V
+ad8220,AD8220ARMZ-R7,max_op_supply_volt,±18 V
+ad8220,AD8220ARMZ-R7,min_op_temp,-40
+ad8220,AD8220ARMZ-R7,max_op_temp,85
+ad8220,AD8220BRMZ,part_family,N
+ad8220,AD8220BRMZ,min_op_supply_volt,±2.25 V
+ad8220,AD8220BRMZ,max_op_supply_volt,±18 V
+ad8220,AD8220BRMZ,min_op_temp,-40
+ad8220,AD8220BRMZ,max_op_temp,85
+ad8220,AD8220BRMZ-RL,part_family,N
+ad8220,AD8220BRMZ-RL,min_op_supply_volt,±2.25 V
+ad8220,AD8220BRMZ-RL,max_op_supply_volt,±18 V
+ad8220,AD8220BRMZ-RL,min_op_temp,-40
+ad8220,AD8220BRMZ-RL,max_op_temp,85
+ad8220,AD8220BRMZ-R7,part_family,N
+ad8220,AD8220BRMZ-R7,min_op_supply_volt,±2.25 V
+ad8220,AD8220BRMZ-R7,max_op_supply_volt,±18 V
+ad8220,AD8220BRMZ-R7,min_op_temp,-40
+ad8220,AD8220BRMZ-R7,max_op_temp,85
+ad8220,AD8220WARMZ,part_family,N
+ad8220,AD8220WARMZ,min_op_supply_volt,±2.25 V
+ad8220,AD8220WARMZ,max_op_supply_volt,±18 V
+ad8220,AD8220WARMZ,min_op_temp,-40
+ad8220,AD8220WARMZ,max_op_temp,125
+ad8220,AD8220WARMZ-RL,part_family,N
+ad8220,AD8220WARMZ-RL,min_op_supply_volt,±2.25 V
+ad8220,AD8220WARMZ-RL,max_op_supply_volt,±18 V
+ad8220,AD8220WARMZ-RL,min_op_temp,-40
+ad8220,AD8220WARMZ-RL,max_op_temp,125
+ad8220,AD8220WARMZ-R7,part_family,N
+ad8220,AD8220WARMZ-R7,min_op_supply_volt,±2.25 V
+ad8220,AD8220WARMZ-R7,max_op_supply_volt,±18 V
+ad8220,AD8220WARMZ-R7,min_op_temp,-40
+ad8220,AD8220WARMZ-R7,max_op_temp,125
+ad823,AD823,part_family,Y
+ad823,AD823,typ_supply_current,5.2 mA
+ad823,AD823,typ_supply_current,5.0 mA
+ad823,AD823,typ_supply_current,7.0 mA
+ad823,AD823,min_op_supply_volt,3 V
+ad823,AD823,max_op_supply_volt,36 V
+ad823,AD823,min_op_temp,-40
+ad823,AD823,max_op_temp,85
+ad823,AD823ANZ,part_family,N
+ad823,AD823ANZ,typ_supply_current,5.2 mA
+ad823,AD823ANZ,typ_supply_current,5.0 mA
+ad823,AD823ANZ,typ_supply_current,7.0 mA
+ad823,AD823ANZ,min_op_supply_volt,3 V
+ad823,AD823ANZ,max_op_supply_volt,36 V
+ad823,AD823ANZ,min_op_temp,-40
+ad823,AD823ANZ,max_op_temp,85
+ad823,AD823AR,part_family,N
+ad823,AD823AR,typ_supply_current,5.2 mA
+ad823,AD823AR,typ_supply_current,5.0 mA
+ad823,AD823AR,typ_supply_current,7.0 mA
+ad823,AD823AR,min_op_supply_volt,3 V
+ad823,AD823AR,max_op_supply_volt,36 V
+ad823,AD823AR,min_op_temp,-40
+ad823,AD823AR,max_op_temp,85
+ad823,AD823AR-REEL,part_family,N
+ad823,AD823AR-REEL,typ_supply_current,5.2 mA
+ad823,AD823AR-REEL,typ_supply_current,5.0 mA
+ad823,AD823AR-REEL,typ_supply_current,7.0 mA
+ad823,AD823AR-REEL,min_op_supply_volt,3 V
+ad823,AD823AR-REEL,max_op_supply_volt,36 V
+ad823,AD823AR-REEL,min_op_temp,-40
+ad823,AD823AR-REEL,max_op_temp,85
+ad823,AD823AR-REEL7,part_family,N
+ad823,AD823AR-REEL7,typ_supply_current,5.2 mA
+ad823,AD823AR-REEL7,typ_supply_current,5.0 mA
+ad823,AD823AR-REEL7,typ_supply_current,7.0 mA
+ad823,AD823AR-REEL7,min_op_supply_volt,3 V
+ad823,AD823AR-REEL7,max_op_supply_volt,36 V
+ad823,AD823AR-REEL7,min_op_temp,-40
+ad823,AD823AR-REEL7,max_op_temp,85
+ad823,AD823ARZ,part_family,N
+ad823,AD823ARZ,typ_supply_current,5.2 mA
+ad823,AD823ARZ,typ_supply_current,5.0 mA
+ad823,AD823ARZ,typ_supply_current,7.0 mA
+ad823,AD823ARZ,min_op_supply_volt,3 V
+ad823,AD823ARZ,max_op_supply_volt,36 V
+ad823,AD823ARZ,min_op_temp,-40
+ad823,AD823ARZ,max_op_temp,85
+ad823,AD823ARZ-RL,part_family,N
+ad823,AD823ARZ-RL,typ_supply_current,5.2 mA
+ad823,AD823ARZ-RL,typ_supply_current,5.0 mA
+ad823,AD823ARZ-RL,typ_supply_current,7.0 mA
+ad823,AD823ARZ-RL,min_op_supply_volt,3 V
+ad823,AD823ARZ-RL,max_op_supply_volt,36 V
+ad823,AD823ARZ-RL,min_op_temp,-40
+ad823,AD823ARZ-RL,max_op_temp,85
+ad823,AD823ARZ-R7,part_family,N
+ad823,AD823ARZ-R7,typ_supply_current,5.2 mA
+ad823,AD823ARZ-R7,typ_supply_current,5.0 mA
+ad823,AD823ARZ-R7,typ_supply_current,7.0 mA
+ad823,AD823ARZ-R7,min_op_supply_volt,3 V
+ad823,AD823ARZ-R7,max_op_supply_volt,36 V
+ad823,AD823ARZ-R7,min_op_temp,-40
+ad823,AD823ARZ-R7,max_op_temp,85
+ad8290,AD8290,part_family,Y
+ad8290,AD8290,typ_supply_current,1.2 mA
+ad8290,AD8290,min_op_supply_volt,2.6 V
+ad8290,AD8290,max_op_supply_volt,5.5 V
+ad8290,AD8290,min_op_temp,-40
+ad8290,AD8290,max_op_temp,85
+ad8290,AD8290ACPZ-R2,part_family,N
+ad8290,AD8290ACPZ-R2,typ_supply_current,1.2 mA
+ad8290,AD8290ACPZ-R2,min_op_supply_volt,2.6 V
+ad8290,AD8290ACPZ-R2,max_op_supply_volt,5.5 V
+ad8290,AD8290ACPZ-R2,min_op_temp,-40
+ad8290,AD8290ACPZ-R2,max_op_temp,85
+ad8290,AD8290ACPZ-R7,part_family,N
+ad8290,AD8290ACPZ-R7,typ_supply_current,1.2 mA
+ad8290,AD8290ACPZ-R7,min_op_supply_volt,2.6 V
+ad8290,AD8290ACPZ-R7,max_op_supply_volt,5.5 V
+ad8290,AD8290ACPZ-R7,min_op_temp,-40
+ad8290,AD8290ACPZ-R7,max_op_temp,85
+ad8290,AD8290ACPZ-RL,part_family,N
+ad8290,AD8290ACPZ-RL,typ_supply_current,1.2 mA
+ad8290,AD8290ACPZ-RL,min_op_supply_volt,2.6 V
+ad8290,AD8290ACPZ-RL,max_op_supply_volt,5.5 V
+ad8290,AD8290ACPZ-RL,min_op_temp,-40
+ad8290,AD8290ACPZ-RL,max_op_temp,85
+ad8390,AD8390,part_family,Y
+ad8390,AD8390,typ_supply_current,5.2 mA
+ad8390,AD8390,typ_supply_current,3.8 mA
+ad8390,AD8390,typ_supply_current,2.5 mA
+ad8390,AD8390,typ_supply_current,0.57 mA
+ad8390,AD8390,typ_supply_current,10.0 mA
+ad8390,AD8390,typ_supply_current,6.7 mA
+ad8390,AD8390,typ_supply_current,0.67 mA
+ad8390,AD8390,typ_supply_current,4.5 mA
+ad8390,AD8390,typ_supply_current,3.3 mA
+ad8390,AD8390,typ_supply_current,2.1 mA
+ad8390,AD8390,typ_supply_current,0.43 mA

--- a/utils/gold_utils/format_gold.py
+++ b/utils/gold_utils/format_gold.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+
+import csv
+
+from normalizers import (
+    gain_bandwidth_normalizer,
+    opamp_part_normalizer,
+    opamp_voltage_normalizer,
+    part_family_normalizer,
+    supply_current_normalizer,
+    temperature_normalizer,
+)
+
+
+def format_gold(raw_gold_file, formatted_gold_file, seen, append=False):
+    delim = ";"
+    with open(raw_gold_file, "r") as csvinput, open(
+        formatted_gold_file, "a"
+    ) if append else open(formatted_gold_file, "w") as csvoutput:
+        writer = csv.writer(csvoutput, lineterminator="\n")
+        reader = csv.reader(csvinput)
+        next(reader, None)  # Skip header row
+        for line in reader:
+            # Parse a CSV line into its components. Currently ignoring
+            # input_bias.
+            (
+                doc_name,
+                part_family,
+                part_num,
+                manufacturer,
+                typ_gbp,
+                typ_supply_current,
+                min_op_supply_volt,
+                max_op_supply_volt,
+                min_op_temp,
+                max_op_temp,
+                notes,
+                annotator,
+            ) = line
+
+            # Map each attribute to its corresponding normalizer
+            name_attr_norm = [
+                ("part_family", part_family, part_family_normalizer),
+                ("typ_gbp", typ_gbp, gain_bandwidth_normalizer),
+                ("typ_supply_current", typ_supply_current, supply_current_normalizer),
+                ("min_op_supply_volt", min_op_supply_volt, opamp_voltage_normalizer),
+                ("max_op_supply_volt", max_op_supply_volt, opamp_voltage_normalizer),
+                ("min_op_temp", min_op_temp, temperature_normalizer),
+                ("max_op_temp", max_op_temp, temperature_normalizer),
+            ]
+
+            part_num = opamp_part_normalizer(part_num)
+
+            # Output tuples of each normalized attribute
+            for name, attr, normalizer in name_attr_norm:
+                if "N/A" not in attr:
+                    for a in attr.split(delim):
+                        if len(a.strip()) > 0:
+                            output = [doc_name, part_num, name, normalizer(a)]
+                            if tuple(output) not in seen:
+                                writer.writerow(output)
+                                seen.add(tuple(output))
+
+
+if __name__ == "__main__":
+    seen = set()  # set for fast O(1) amortized lookup
+    # Transform dev set
+    raw_dev_gold = "/home/nchiang/repos/hack/opamps/data/test/test_gold.csv"
+    formatted_gold = "/home/nchiang/repos/hack/opamps/data/test/formatted_test_gold.csv"
+    format_gold(raw_dev_gold, formatted_gold, seen)

--- a/utils/gold_utils/normalizers.py
+++ b/utils/gold_utils/normalizers.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python
+
+import pdb
+
+
+def split_val_condition(input_string):
+    """
+    Split and return a {'value': v, 'condition': c} dict for the value
+    and the condition.
+    Condition is empty if no condition was found.
+
+    @param input    A string of the form XXX @ YYYY
+    """
+    try:
+        (value, condition) = [x.strip() for x in input_string.split("@")]
+        return {"value": value, "condition": condition}
+    except ValueError:
+        # no condition was found
+        return {"value": input_string.strip(), "condition": None}
+
+
+def part_family_normalizer(family):
+    if family == "Y":
+        return str(family)
+    elif family == "N":
+        return str(family)
+    else:
+        print("[ERROR]: Invalid part family")
+        pdb.set_trace()
+
+
+def transistor_part_normalizer(part):
+    # Part number normalization
+    return part.replace(" ", "").upper()
+
+
+def opamp_part_normalizer(part):
+    # TODO: Digikey actually has weird formatting on their part numbers,
+    #       which will require more normalization than we had to do with
+    #       transistors.
+    return part.replace(" ", "").upper()
+
+
+def gain_bandwidth_normalizer(gbp):
+    """
+    Normalize the gain bandwidth product into kHz.
+    """
+    parse = split_val_condition(gbp)
+
+    # NOTE: We currently ignore the conditions
+
+    # Process Units
+    try:
+        (value, unit) = parse["value"].split(" ")
+        value = float(value)
+        """
+        if unit == "MHz":
+            value = value * 1000
+        elif unit == "kHz":
+            # already kHz
+            pass
+        """
+        return str(value) + " " + unit
+
+    except Exception:
+        print("[ERROR]: " + str(parse))
+        pdb.set_trace()
+
+
+def supply_current_normalizer(supply_current):
+    """
+    Normalize input quiescent supply current to uA
+    """
+    # NOTE: Currently ignoring the conditions.
+    parse = split_val_condition(supply_current)
+
+    # Process Units
+    try:
+        (value, unit) = parse["value"].split(" ")
+        value = float(value)
+        """
+        if unit == "mA":
+            value = value * 1000
+        elif unit == "nA":
+            value = value / 1000
+        """
+        return str(value) + " " + unit
+    except Exception:
+        print("[ERROR]: " + str(parse))
+        pdb.set_trace()
+
+
+def opamp_voltage_normalizer(supply_voltage):
+    """
+    Normalize supply voltage into absolute values (remove +/-)
+    """
+    parse = split_val_condition(supply_voltage)
+
+    try:
+        if parse["value"].startswith("± "):
+            parse["value"] = parse["value"].replace("± ", "±")
+        (value, unit) = parse["value"].split(" ")
+    except Exception:
+        print("[ERROR]: " + str(parse))
+        pdb.set_trace()
+
+    if unit != "V":
+        print("[ERROR]: Invalid supply voltage")
+        pdb.set_trace()
+
+    return str(value) + " " + unit
+
+
+def temperature_normalizer(temperature):
+    try:
+        (temp, unit) = temperature.rsplit(" ", 1)
+        if unit != "C":
+            pdb.set_trace()
+        return int(temp)
+    except Exception:
+        print("[ERROR]: Incorrect Temperature Value")
+        pdb.set_trace()
+
+
+def polarity_normalizer(polarity):
+    try:
+        if polarity in ["NPN", "PNP"]:
+            return polarity
+    except Exception:
+        print("[ERROR]: Incorrect Polarity Value")
+        pdb.set_trace()
+
+
+def dissipation_normalizer(dissipation):
+    if dissipation[0] == " ":
+        dissipation = dissipation[1:]
+    return str(abs(round(float(dissipation.split(" ")[0]), 1)))
+
+
+def current_normalizer(current):
+    if current[0] == " ":
+        current = current[1:]
+    return str(abs(round(float(current.split(" ")[0]), 1)))
+
+
+def voltage_normalizer(voltage):
+    voltage = voltage.replace("K", "000")
+    voltage = voltage.replace("k", "000")
+    return voltage.split(" ")[0].replace("-", "")
+
+
+def gain_normalizer(gain):
+    gain = gain.split("@")[0]
+    gain = gain.strip()
+    gain = gain.replace(",", "")
+    gain = gain.replace("K", "000")
+    gain = gain.replace("k", "000")
+    return str(abs(round(float(gain.split(" ")[0]), 1)))
+
+
+def old_dev_gain_normalizer(gain):
+    return str(abs(round(float(gain), 1)))


### PR DESCRIPTION
Add gold labels for `opamps/dev/` and `opamps/test/`.

Also adds gold normalizers and other useful scripts to `utils/gold_utils`. (Originally from [dl-datasheets](https://github.com/lukehsiao/dl-datasheets/tree/master/gold_utils), but have been modified enough to deserve their own location)