### PR TITLE
fix(opamps): properly name candidates_to_entities in utils

### DIFF
--- a/hack/opamps/opamp_utils.py
+++ b/hack/opamps/opamp_utils.py
@@ -233,7 +233,7 @@ def entity_level_scores(entities, metric=None, docs=None, corpus=None, is_gain=T
     )
 
 
-def candidiates_to_entities(candidates, is_gain=True):
+def candidates_to_entities(candidates, is_gain=True):
     # Turn CandidateSet into set of tuples
     entities = set()
     for c in candidates:


### PR DESCRIPTION
This ensures that `opamps.py` is up and running after changing the gold data to include `manuf`.