### PR TITLE
fix(opamps): only log relation relevant data

### DIFF
--- a/hack/opamps/opamps.py
+++ b/hack/opamps/opamps.py
@@ -275,8 +275,12 @@ def main(
         mention_extractor.apply(docs, parallelism=parallel)
 
     logger.info(f"Total Mentions: {session.query(Mention).count()}")
-    logger.info(f"Total Gain: {session.query(Gain).count()}")
-    logger.info(f"Total Current: {session.query(Current).count()}")
+
+    if gain:
+        logger.info(f"Total Gain: {session.query(Gain).count()}")
+
+    if current:
+        logger.info(f"Total Current: {session.query(Current).count()}")
 
     cand_classes = []
     if gain:


### PR DESCRIPTION
This fixes an error I was getting while running `opamps` on only `--typ-gbp` where `current` was undefined while querying the database for a log message.