### PR TITLE
fix(setup.py): enforce Snorkel is before v0.9.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         "quantiphy",
         "scipy",
         "seaborn",
-        "snorkel>=0.9.5",
+        "snorkel>=0.9.5, <0.9.7",
         "statsmodels",
         "torch>=1.3.0,<2.0.0",
         "tqdm",


### PR DESCRIPTION
Snorkel v0.9.7 introduced some breaking dependency changes that this HACK repository isn't compatible with:
```
ERROR: snorkel 0.9.7 has requirement numpy<1.20.0,>=1.16.5, but you'll have numpy 1.20.1 which is incompatible.
ERROR: snorkel 0.9.7 has requirement pandas<2.0.0,>=1.0.0, but you'll have pandas 0.25.3 which is incompatible.
```

See: https://github.com/snorkel-team/snorkel/releases/tag/v0.9.7